### PR TITLE
feat: add Qovery Console URL detection to all 5 skills

### DIFF
--- a/qovery-deploy/SKILL.md
+++ b/qovery-deploy/SKILL.md
@@ -23,6 +23,57 @@ Use this skill when the user says anything like:
 
 ---
 
+## Qovery Console URL Detection
+
+When the user provides a Qovery Console URL (from `console.qovery.com` or `new-console.qovery.com`), extract the resource IDs directly from the URL path. This saves significant back-and-forth — no need to ask which organization, project, environment, or service the user means.
+
+**URL format:**
+```
+https://{console.qovery.com|new-console.qovery.com}/organization/{orgId}/project/{projectId}/environment/{envId}/service/{serviceId}[/{page}]
+```
+
+**Extraction rules:**
+- `orgId` — UUID after `/organization/`
+- `projectId` — UUID after `/project/`
+- `envId` — UUID after `/environment/`
+- `serviceId` — UUID after `/service/`
+- `page` — optional suffix (`service-logs`, `deployment-logs`, `general`, `variables`, `settings`, etc.) gives context about what the user is viewing
+
+Not every URL contains all segments. Use whatever IDs are present:
+- URL with only `orgId` -> organization is known, still ask about project/environment/service
+- URL with `orgId` + `projectId` + `envId` -> environment is known, may still need service selection
+- URL with all four IDs -> fully resolved, proceed directly
+
+**After extracting IDs, resolve names via the API to confirm with the user:**
+```bash
+# Get organization name
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq '.results[] | select(.id == "{orgId}") | {id, name}'
+
+# Get project name
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/project/{projectId}" | jq '{id, name}'
+
+# Get environment name + all service names/statuses in one call
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}/statuses" | jq '{
+    environment: .environment.state,
+    applications: [.applications[] | {id, name: .name, state}],
+    containers: [.containers[] | {id, name: .name, state}],
+    databases: [.databases[] | {id, name: .name, state}],
+    jobs: [.jobs[] | {id, name: .name, state}],
+    helms: [.helms[] | {id, name: .name, state}]
+  }'
+
+# Get cluster ID from the environment (the environment knows its cluster)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}" | jq '{cluster_id: .cluster_id}'
+```
+
+**Use the extracted IDs directly** in all subsequent API calls and skip any discovery questions for resources already identified by the URL.
+
+---
+
 ## PHASE 1: Discovery & User Questionnaire
 
 Before doing anything, you MUST gather information by asking the user these questions. Do NOT skip this phase. Ask them conversationally, not as a wall of text — group related questions together.
@@ -40,6 +91,8 @@ Before asking any questions, try to detect an existing token automatically:
 - Tokens should be stored securely (never commit to git)
 
 #### Step 2: Resolve Organization
+
+**Shortcut:** If the user provided a Qovery Console URL, extract the organization ID (and any other IDs) from it using the URL Detection rules above. Use the extracted IDs directly and skip the resolution questions for any resources already identified. You can still resolve names via the API to confirm with the user what was detected.
 
 After authenticating, **proactively list all organizations** the user has access to:
 

--- a/qovery-onboard/SKILL.md
+++ b/qovery-onboard/SKILL.md
@@ -29,9 +29,50 @@ Use this skill when the user says anything like:
 
 ---
 
+## Qovery Console URL Detection
+
+When the user provides a Qovery Console URL (from `console.qovery.com` or `new-console.qovery.com`), extract the resource IDs directly from the URL path. For the onboarding skill, this tells you the user already has a Qovery account and at least an organization — you can skip account creation questions entirely.
+
+**URL format:**
+```
+https://{console.qovery.com|new-console.qovery.com}/organization/{orgId}/project/{projectId}/environment/{envId}/service/{serviceId}[/{page}]
+```
+
+**Extraction rules:**
+- `orgId` — UUID after `/organization/`
+- `projectId` — UUID after `/project/`
+- `envId` — UUID after `/environment/`
+- `serviceId` — UUID after `/service/`
+
+Not every URL contains all segments. Use whatever IDs are present to understand what the user has already set up:
+- URL with only `orgId` -> they have an account and org, skip account creation, check what's already configured
+- URL with `orgId` + `projectId` -> they have a project, check if they need environments/clusters
+- URL with full path -> they have a running service, onboarding may focus on optimization, team setup, or extending their configuration
+
+**After extracting IDs, resolve current state via the API:**
+```bash
+# Get organization name and plan
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq '.results[] | select(.id == "{orgId}") | {id, name, plan}'
+
+# Get clusters (check if any exist)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization/{orgId}/cluster" | jq '.results[] | {id, name, cloud_provider, region, status}'
+
+# Get projects
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization/{orgId}/project" | jq '.results[] | {id, name}'
+```
+
+**Use the extracted IDs directly** to understand the user's current setup and skip onboarding steps they've already completed.
+
+---
+
 ## PHASE 1: Understand the User
 
 Before doing anything, UNDERSTAND who the user is. Ask questions conversationally — NOT as a wall of text. Group related questions together. Adapt follow-up questions based on their answers. Skip questions that are already answered by context.
+
+**Shortcut:** If the user provided a Qovery Console URL, they already have an account. Extract the organization ID (and any other IDs) from the URL using the URL Detection rules above. Use these to query what's already set up (clusters, projects, environments) and skip questions about resources that already exist. Focus the onboarding conversation on what's NOT yet configured.
 
 ### Group 1: Who Are You?
 

--- a/qovery-optimize/SKILL.md
+++ b/qovery-optimize/SKILL.md
@@ -37,11 +37,58 @@ Use this skill when the user says anything like:
 
 ---
 
+## Qovery Console URL Detection
+
+When the user provides a Qovery Console URL (from `console.qovery.com` or `new-console.qovery.com`), extract the resource IDs directly from the URL path. This immediately scopes the optimization analysis — you know which organization, project, environment, or service the user wants to optimize.
+
+**URL format:**
+```
+https://{console.qovery.com|new-console.qovery.com}/organization/{orgId}/project/{projectId}/environment/{envId}/service/{serviceId}[/{page}]
+```
+
+**Extraction rules:**
+- `orgId` — UUID after `/organization/`
+- `projectId` — UUID after `/project/`
+- `envId` — UUID after `/environment/`
+- `serviceId` — UUID after `/service/`
+
+Not every URL contains all segments. Use whatever IDs are present to scope the analysis:
+- URL with only `orgId` -> optimize across the entire organization (all clusters, all environments)
+- URL with `orgId` + `projectId` -> optimize all environments in that project
+- URL with `envId` -> optimize that specific environment
+- URL with `serviceId` -> focus on right-sizing that specific service
+
+**After extracting IDs, use them directly for inventory and cost analysis:**
+```bash
+# Get organization name
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq '.results[] | select(.id == "{orgId}") | {id, name}'
+
+# Get all clusters in the organization
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization/{orgId}/cluster" | jq '.results[] | {id, name, cloud_provider, region, status}'
+
+# Get environment services and their resource allocations
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}/statuses" | jq '{
+    applications: [.applications[] | {id, name: .name, state}],
+    containers: [.containers[] | {id, name: .name, state}],
+    databases: [.databases[] | {id, name: .name, state}],
+    jobs: [.jobs[] | {id, name: .name, state}]
+  }'
+```
+
+**Use the extracted IDs directly** in all subsequent API calls — skip asking the user to identify which organization, environment, or service to optimize.
+
+---
+
 ## PHASE 1: Context Gathering & Business Understanding
 
 Before optimizing, you MUST understand the business context. Blind optimization without context leads to outages.
 
 ### 1.1 Authenticate & Inventory
+
+**Shortcut:** If the user provided a Qovery Console URL, extract the organization ID and any other IDs from it using the URL Detection rules above. Use the extracted IDs to scope the inventory and cost analysis — e.g., if a specific environment ID is provided, focus the optimization on that environment's services rather than scanning the entire organization.
 
 Use the same authentication flow as the other Qovery skills:
 1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set

--- a/qovery-speedup/SKILL.md
+++ b/qovery-speedup/SKILL.md
@@ -29,9 +29,53 @@ Use this skill when the user says anything like:
 
 ---
 
+## Qovery Console URL Detection
+
+When the user provides a Qovery Console URL (from `console.qovery.com` or `new-console.qovery.com`), extract the resource IDs directly from the URL path. This immediately identifies which organization, project, environment, and service the user wants to speed up — no need to ask.
+
+**URL format:**
+```
+https://{console.qovery.com|new-console.qovery.com}/organization/{orgId}/project/{projectId}/environment/{envId}/service/{serviceId}[/{page}]
+```
+
+**Extraction rules:**
+- `orgId` — UUID after `/organization/`
+- `projectId` — UUID after `/project/`
+- `envId` — UUID after `/environment/`
+- `serviceId` — UUID after `/service/`
+- `page` — optional suffix (`deployment-logs` is especially relevant — the user is likely looking at a slow deployment)
+
+Not every URL contains all segments. Use whatever IDs are present:
+- URL with `envId` -> use it directly in the V2 deployment history API call
+- URL with `serviceId` -> focus the speed analysis on that specific service
+- URL with `deployment-logs` page -> the user is likely watching a slow deployment right now
+
+**After extracting IDs, use them directly in the deployment history API:**
+```bash
+# Get deployment history for the environment (V2 — includes per-stage, per-service durations)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}/deploymentHistory?version=v2" | jq '.results[0:5]'
+
+# Get environment name + all services
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}/statuses" | jq '{
+    environment: .environment.state,
+    applications: [.applications[] | {id, name: .name, state}],
+    containers: [.containers[] | {id, name: .name, state}],
+    jobs: [.jobs[] | {id, name: .name, state}],
+    helms: [.helms[] | {id, name: .name, state}]
+  }'
+```
+
+**Use the extracted IDs directly** in all subsequent API calls — skip asking the user to identify which environment or service is slow.
+
+---
+
 ## PHASE 1: Measure — Deployment Timeline Analysis
 
 Before optimizing anything, MEASURE where time is actually being spent. Do NOT guess — use data.
+
+**Shortcut:** If the user provided a Qovery Console URL, extract the environment ID and/or service ID from it using the URL Detection rules above. Use the environment ID directly in the V2 deployment history API call below, and use the service ID to focus the timeline analysis on that specific service. Skip asking "which environment/service is slow?"
 
 ### 1.1 Gather Structured Deployment History (V2 API)
 

--- a/qovery-troubleshoot/SKILL.md
+++ b/qovery-troubleshoot/SKILL.md
@@ -32,6 +32,57 @@ Use this skill when the user says anything like:
 
 ---
 
+## Qovery Console URL Detection
+
+When the user provides a Qovery Console URL (from `console.qovery.com` or `new-console.qovery.com`), extract the resource IDs directly from the URL path. This is especially valuable for troubleshooting — it immediately tells you which organization, project, environment, and service the user needs help with.
+
+**URL format:**
+```
+https://{console.qovery.com|new-console.qovery.com}/organization/{orgId}/project/{projectId}/environment/{envId}/service/{serviceId}[/{page}]
+```
+
+**Extraction rules:**
+- `orgId` — UUID after `/organization/`
+- `projectId` — UUID after `/project/`
+- `envId` — UUID after `/environment/`
+- `serviceId` — UUID after `/service/`
+- `page` — optional suffix that hints at the problem area:
+  - `service-logs` -> user is looking at runtime logs, likely a crash or error
+  - `deployment-logs` -> user is looking at build/deploy logs, likely a deployment failure
+  - `general` / `settings` -> user may be checking configuration
+  - `variables` -> user may suspect an environment variable issue
+
+Not every URL contains all segments. Use whatever IDs are present:
+- URL with only `orgId` -> organization is known, still ask about environment/service
+- URL with `orgId` + `projectId` + `envId` -> environment is known, may still need service selection
+- URL with all four IDs -> fully resolved, skip directly to fetching service status and logs
+
+**After extracting IDs, resolve names and current status via the API:**
+```bash
+# Get organization name
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq '.results[] | select(.id == "{orgId}") | {id, name}'
+
+# Get environment name + all service names/statuses in one call
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}/statuses" | jq '{
+    environment: .environment.state,
+    applications: [.applications[] | {id, name: .name, state}],
+    containers: [.containers[] | {id, name: .name, state}],
+    databases: [.databases[] | {id, name: .name, state}],
+    jobs: [.jobs[] | {id, name: .name, state}],
+    helms: [.helms[] | {id, name: .name, state}]
+  }'
+
+# Get cluster ID from the environment
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}" | jq '{cluster_id: .cluster_id}'
+```
+
+**Use the extracted IDs directly** in all subsequent diagnostic API calls — skip the "which service has the problem?" question if the service ID is already in the URL. The page suffix also provides a hint about what to investigate first (e.g., if the user was on `service-logs`, fetch logs immediately).
+
+---
+
 ## MCP Server Integration
 
 This skill is designed to work with the **Qovery MCP Server** as the primary diagnostic interface. The MCP Server provides faster, more structured responses than raw CLI/API calls and is optimized for troubleshooting.
@@ -111,9 +162,11 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
 
 ### 1.3 Identify the Problem
 
+**Shortcut:** If the user provided a Qovery Console URL with a service ID, use the extracted IDs to skip directly to fetching the service status and logs. The URL page suffix (`service-logs`, `deployment-logs`, etc.) hints at the problem area — use it to focus your initial investigation. You can skip question 1 below entirely if the service ID is already known from the URL.
+
 Ask the user or detect from service statuses:
 
-1. **Which service has the problem?** (name or detect from error states)
+1. **Which service has the problem?** (name or detect from error states, or extracted from Console URL)
 2. **What are you experiencing?** Categorize into:
    - **Won't deploy** — build error, deployment error, stuck
    - **Crashes** — starts but dies (CrashLoopBackOff, OOM, segfault)


### PR DESCRIPTION
## Summary

When users paste a Qovery Console URL like:
```
https://console.qovery.com/organization/{orgId}/project/{projectId}/environment/{envId}/service/{serviceId}/service-logs
```

The agent now extracts the organization, project, environment, and service IDs directly from the URL path, skipping redundant discovery questions. Both `console.qovery.com` and `new-console.qovery.com` are supported.

## Changes per Skill

| Skill | URL Detection Section | Phase 1 Shortcut | Skill-Specific Behavior |
|-------|----------------------|-------------------|------------------------|
| **qovery-deploy** | +45 lines | Step 2 note | Skips org/cluster/project resolution; resolves cluster from environment |
| **qovery-troubleshoot** | +47 lines | Phase 1.3 note | Skips "which service?" question; uses page suffix (`service-logs`, `deployment-logs`) to focus investigation |
| **qovery-onboard** | +39 lines | Phase 1 intro note | Detects user already has account; skips creation steps; focuses on what's NOT configured |
| **qovery-speedup** | +40 lines | Phase 1 intro note | Uses `envId` directly in V2 deployment history API; focuses on specific service if `serviceId` present |
| **qovery-optimize** | +45 lines | Phase 1.1 note | Scopes cost analysis to the specific org/env/service from URL |

## URL Format Supported

```
https://{console.qovery.com|new-console.qovery.com}/organization/{orgId}[/project/{projectId}[/environment/{envId}[/service/{serviceId}[/{page}]]]]
```

Page suffixes (`service-logs`, `deployment-logs`, `general`, `variables`, `settings`) provide additional context about what the user is looking at.

## How It Works

1. Agent detects a Console URL in the user's message
2. Extracts whatever IDs are present (not all segments required)
3. Resolves names via API to confirm with the user
4. Skips discovery questions for any resources already identified by the URL
5. Uses extracted IDs directly in all subsequent API calls