### PR TITLE
feat: add slash commands for all 6 Qovery skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,27 @@ The onboard skill acts as your personal cloud architect. The deploy skill handle
 - _"Preview this branch on Qovery"_
 - `/qovery-preview` (slash command)
 
+## Slash Commands
+
+Each skill includes a slash command for quick invocation. Type `/` followed by the command name in your AI tool's chat:
+
+| Command | What it does | Example |
+|---------|-------------|---------|
+| `/qovery-deploy` | Deploy the current project to Kubernetes | `/qovery-deploy` or `/qovery-deploy my-app` |
+| `/qovery-troubleshoot` | Diagnose and fix a failing service | `/qovery-troubleshoot` or `/qovery-troubleshoot backend` |
+| `/qovery-onboard` | Start guided Qovery onboarding | `/qovery-onboard` or `/qovery-onboard migrating from Heroku` |
+| `/qovery-optimize` | Analyze costs and right-size resources | `/qovery-optimize` or `/qovery-optimize production` |
+| `/qovery-speedup` | Analyze and fix deployment bottlenecks | `/qovery-speedup` or `/qovery-speedup my-service` |
+| `/qovery-preview` | Create a preview environment for a PR | `/qovery-preview` or `/qovery-preview PR-123` |
+
+Commands are installed automatically by the install script. They accept optional arguments (service name, environment name, Console URL) and auto-detect context from your git workspace.
+
+**Manual command installation** (if not using the install script):
+```bash
+mkdir -p ~/.config/opencode/commands
+cp qovery-*/commands/*.md ~/.config/opencode/commands/
+```
+
 ## Prerequisites
 
 Before deploying, you need:

--- a/local-install.sh
+++ b/local-install.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================
+# Qovery Skills — Local Dev Installer (Symlinks)
+# Creates symlinks from this repo to the standard skill paths.
+# Edits in the repo are instantly available — no re-install needed.
+# https://github.com/Qovery/qovery-skills
+# ============================================================
+
+SKILLS=("qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview")
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Colors (if terminal supports them)
+if [ -t 1 ]; then
+  GREEN='\033[0;32m'
+  BLUE='\033[0;34m'
+  YELLOW='\033[0;33m'
+  RED='\033[0;31m'
+  BOLD='\033[1m'
+  NC='\033[0m'
+else
+  GREEN='' BLUE='' YELLOW='' RED='' BOLD='' NC=''
+fi
+
+# Verify we're in the repo
+if [ ! -f "$REPO_DIR/qovery-deploy/SKILL.md" ]; then
+  echo -e "${RED}Error:${NC} Cannot find qovery-deploy/SKILL.md in $REPO_DIR"
+  echo "Make sure this script is in the qovery-skills repo root."
+  exit 1
+fi
+
+usage() {
+  cat <<EOF
+${BOLD}Qovery Skills — Local Dev Installer (Symlinks)${NC}
+
+Creates symlinks from this repo to the standard skill installation paths.
+Edits in the repo are instantly reflected — no re-install needed.
+
+Usage:
+  local-install.sh [OPTIONS]
+
+Options:
+  --global      Install globally (default) — available in all projects
+  --project     Install in the current project directory only
+  --uninstall   Remove all Qovery skill symlinks from all known locations
+  --help        Show this help message
+
+Examples:
+  # Symlink globally (recommended for development)
+  ./local-install.sh
+
+  # Symlink in current project only
+  ./local-install.sh --project
+
+  # Remove all symlinks
+  ./local-install.sh --uninstall
+EOF
+  exit 0
+}
+
+# Parse arguments
+MODE="global"
+for arg in "$@"; do
+  case "$arg" in
+    --global)    MODE="global" ;;
+    --project)   MODE="project" ;;
+    --uninstall) MODE="uninstall" ;;
+    --help|-h)   usage ;;
+    *)
+      echo -e "${RED}Unknown option: $arg${NC}"
+      echo "Run with --help for usage."
+      exit 1
+      ;;
+  esac
+done
+
+# Determine target base directories (without skill name)
+get_base_dirs() {
+  local mode="$1"
+  if [ "$mode" = "global" ]; then
+    echo "$HOME/.claude/skills"
+    echo "$HOME/.config/opencode/skills"
+    echo "$HOME/.agents/skills"
+  elif [ "$mode" = "project" ]; then
+    echo ".claude/skills"
+    echo ".opencode/skills"
+    echo ".agents/skills"
+  fi
+}
+
+# Helper: remove an existing target (symlink, file, or directory)
+# Returns 0 if something was removed, 1 if nothing existed
+remove_existing() {
+  local target="$1"
+  if [ -L "$target" ]; then
+    rm "$target"
+    return 0
+  elif [ -e "$target" ]; then
+    echo -e "    ${YELLOW}Warning:${NC} $target exists and is not a symlink — replacing it"
+    rm -rf "$target"
+    return 0
+  fi
+  return 1
+}
+
+# Uninstall
+if [ "$MODE" = "uninstall" ]; then
+  echo -e "${BOLD}Removing Qovery skill symlinks...${NC}"
+  echo ""
+  found=0
+
+  BASE_PATHS=(
+    "$HOME/.claude/skills"
+    "$HOME/.config/opencode/skills"
+    "$HOME/.agents/skills"
+    ".claude/skills"
+    ".opencode/skills"
+    ".agents/skills"
+  )
+
+  CMD_PATHS=(
+    "$HOME/.claude/commands"
+    "$HOME/.config/opencode/commands"
+    "$HOME/.agents/commands"
+    ".claude/commands"
+    ".opencode/commands"
+    ".agents/commands"
+  )
+
+  # Remove skill symlinks
+  for base in "${BASE_PATHS[@]}"; do
+    for skill in "${SKILLS[@]}"; do
+      target="$base/$skill"
+      if [ -L "$target" ]; then
+        rm "$target"
+        echo -e "  ${RED}Removed symlink${NC} $target"
+        found=1
+      elif [ -d "$target" ] && [ -f "$target/SKILL.md" ]; then
+        echo -e "  ${YELLOW}Skipped${NC} $target (not a symlink — use install.sh --uninstall to remove copies)"
+      fi
+    done
+  done
+
+  # Remove command symlinks
+  for cmd_base in "${CMD_PATHS[@]}"; do
+    for skill in "${SKILLS[@]}"; do
+      cmd_name="${skill}"
+      cmd_target="$cmd_base/$cmd_name.md"
+      if [ -L "$cmd_target" ]; then
+        rm "$cmd_target"
+        echo -e "  ${RED}Removed symlink${NC} $cmd_target"
+        found=1
+      fi
+    done
+  done
+
+  if [ "$found" = "0" ]; then
+    echo "  No symlinks found."
+  else
+    echo ""
+    echo -e "${GREEN}Uninstall complete.${NC}"
+  fi
+  exit 0
+fi
+
+# Install (symlinks)
+echo -e "${BOLD}Installing Qovery skills (symlinks)...${NC}"
+echo -e "  Source: ${BLUE}$REPO_DIR${NC}"
+echo ""
+
+installed=0
+
+for skill in "${SKILLS[@]}"; do
+  skill_source="$REPO_DIR/$skill"
+
+  # Skip skills that don't exist in the repo yet
+  if [ ! -f "$skill_source/SKILL.md" ]; then
+    echo -e "  ${YELLOW}[$skill]${NC} — skipped (not found in repo)"
+    echo ""
+    continue
+  fi
+
+  echo -e "  ${BLUE}[$skill]${NC}"
+
+  while IFS= read -r base; do
+    target="$base/$skill"
+    mkdir -p "$base"
+    remove_existing "$target" || true
+    ln -s "$skill_source" "$target"
+    echo -e "    ${GREEN}Linked${NC} $target -> $skill_source"
+    installed=$((installed + 1))
+  done < <(get_base_dirs "$MODE")
+
+  echo ""
+done
+
+# Install slash commands (symlink individual .md files)
+cmd_installed=0
+for skill in "${SKILLS[@]}"; do
+  CMD_DIR="$REPO_DIR/$skill/commands"
+  if [ -d "$CMD_DIR" ]; then
+    for cmd_file in "$CMD_DIR"/*.md; do
+      [ -f "$cmd_file" ] || continue
+      cmd_name=$(basename "$cmd_file" .md)
+
+      while IFS= read -r base; do
+        cmd_target_dir="$(dirname "$base")/commands"
+        cmd_target="$cmd_target_dir/$cmd_name.md"
+        mkdir -p "$cmd_target_dir"
+        remove_existing "$cmd_target" || true
+        ln -s "$cmd_file" "$cmd_target"
+        echo -e "  ${GREEN}Linked${NC} /$cmd_name -> $cmd_target"
+        cmd_installed=$((cmd_installed + 1))
+      done < <(get_base_dirs "$MODE")
+    done
+  fi
+done
+
+echo ""
+echo -e "${GREEN}${BOLD}Successfully linked ${#SKILLS[@]} skills to $installed locations.${NC}"
+if [ "$cmd_installed" -gt 0 ]; then
+  echo -e "${GREEN}${BOLD}Linked $cmd_installed slash command(s).${NC}"
+fi
+echo ""
+
+if [ "$MODE" = "global" ]; then
+  echo -e "Skills are now available ${BOLD}globally${NC} in all your projects."
+else
+  echo -e "Skills are now available in ${BOLD}this project${NC} only."
+fi
+
+echo ""
+echo -e "${BOLD}Skills linked:${NC}"
+echo -e "  ${YELLOW}qovery-onboard${NC}       — Guided onboarding for new Qovery users"
+echo -e "  ${YELLOW}qovery-deploy${NC}        — Deploy any app to Kubernetes with Qovery"
+echo -e "  ${YELLOW}qovery-troubleshoot${NC}  — Diagnose and fix deployment issues"
+echo -e "  ${YELLOW}qovery-optimize${NC}      — Optimize costs and right-size resources"
+echo -e "  ${YELLOW}qovery-speedup${NC}       — Speed up deployments and builds"
+echo -e "  ${YELLOW}qovery-preview${NC}       — Create preview environments from PRs"
+echo ""
+echo -e "${BOLD}Slash commands:${NC}"
+echo -e "  ${YELLOW}/qovery-deploy${NC}  ${YELLOW}/qovery-troubleshoot${NC}  ${YELLOW}/qovery-onboard${NC}"
+echo -e "  ${YELLOW}/qovery-optimize${NC}  ${YELLOW}/qovery-speedup${NC}  ${YELLOW}/qovery-preview${NC}"
+echo ""
+echo -e "Changes in ${BLUE}$REPO_DIR${NC} are now ${BOLD}instantly available${NC} — no re-install needed."
+echo ""
+echo -e "Documentation: ${BLUE}https://github.com/Qovery/qovery-skills${NC}"

--- a/qovery-deploy/SKILL.md
+++ b/qovery-deploy/SKILL.md
@@ -20,6 +20,7 @@ Use this skill when the user says anything like:
 - "I want to deploy this to Kubernetes"
 - "Help me deploy to the cloud with Qovery"
 - "Can you create a Qovery configuration for my app?"
+- `/qovery-deploy` (slash command)
 
 ---
 

--- a/qovery-deploy/commands/qovery-deploy.md
+++ b/qovery-deploy/commands/qovery-deploy.md
@@ -1,0 +1,16 @@
+---
+description: Deploy the current project to Kubernetes using Qovery
+---
+
+Deploy the current project to Kubernetes using Qovery.
+
+If arguments are provided, use them as context:
+- `$ARGUMENTS` — application name, Qovery Console URL, or additional instructions
+
+Analyze the codebase to detect the language, framework, and services. Follow the
+qovery-deploy skill to gather requirements, create Dockerfiles if needed, and deploy.
+
+Project files detected:
+!`ls package.json go.mod requirements.txt pyproject.toml Pipfile pom.xml build.gradle build.gradle.kts Gemfile composer.json *.csproj *.sln Dockerfile docker-compose.yml docker-compose.yaml .env.example Chart.yaml *.tf 2>/dev/null || echo "no known project files found"`
+Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
+Git remote: !`git remote get-url origin 2>/dev/null || echo "unknown"`

--- a/qovery-onboard/SKILL.md
+++ b/qovery-onboard/SKILL.md
@@ -26,6 +26,7 @@ Use this skill when the user says anything like:
 - "What's the best way to set up Qovery for my use case?"
 - "I'm migrating from Heroku/Vercel/Render to Qovery"
 - "How do I set up Qovery for my team?"
+- `/qovery-onboard` (slash command)
 
 ---
 

--- a/qovery-onboard/commands/qovery-onboard.md
+++ b/qovery-onboard/commands/qovery-onboard.md
@@ -1,0 +1,11 @@
+---
+description: Get started with Qovery — guided onboarding
+---
+
+Start the Qovery guided onboarding process.
+
+If arguments are provided, use them as context:
+- `$ARGUMENTS` — your role (developer, devops, CTO), cloud provider preference, or migration source (Heroku, Vercel, Render)
+
+Follow the qovery-onboard skill to understand your context, recommend the
+optimal Qovery configuration, and set everything up.

--- a/qovery-optimize/SKILL.md
+++ b/qovery-optimize/SKILL.md
@@ -34,6 +34,7 @@ Use this skill when the user says anything like:
 - "How much is my infrastructure costing me?"
 - "Generate a cost report"
 - "I want to reduce my AWS/GCP/Azure bill"
+- `/qovery-optimize` (slash command)
 
 ---
 

--- a/qovery-optimize/commands/qovery-optimize.md
+++ b/qovery-optimize/commands/qovery-optimize.md
@@ -1,0 +1,11 @@
+---
+description: Optimize Qovery costs and right-size resources
+---
+
+Analyze and optimize costs for Qovery services, environments, or the entire organization.
+
+If arguments are provided, use them as context:
+- `$ARGUMENTS` — environment name (e.g., "production"), service name, or Qovery Console URL
+
+Follow the qovery-optimize skill to analyze resource consumption, understand
+business context, and generate a cost optimization report with actionable recommendations.

--- a/qovery-speedup/SKILL.md
+++ b/qovery-speedup/SKILL.md
@@ -26,6 +26,7 @@ Use this skill when the user says anything like:
 - "How can I deploy faster?"
 - "My image pull is slow"
 - "Can you analyze my deployment pipeline?"
+- `/qovery-speedup` (slash command)
 
 ---
 

--- a/qovery-speedup/commands/qovery-speedup.md
+++ b/qovery-speedup/commands/qovery-speedup.md
@@ -1,0 +1,14 @@
+---
+description: Speed up Qovery deployments by analyzing bottlenecks
+---
+
+Analyze and optimize deployment speed for a Qovery service or environment.
+
+If arguments are provided, use them as context:
+- `$ARGUMENTS` — service name, environment name, or Qovery Console URL
+
+Follow the qovery-speedup skill to measure deployment timelines, identify
+bottlenecks (build, startup, health check, scheduling, image pull), and apply optimizations.
+
+Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
+Git remote: !`git remote get-url origin 2>/dev/null || echo "unknown"`

--- a/qovery-troubleshoot/SKILL.md
+++ b/qovery-troubleshoot/SKILL.md
@@ -29,6 +29,7 @@ Use this skill when the user says anything like:
 - "My Qovery costs are too high"
 - "My cluster is not responding"
 - "What's broken?"
+- `/qovery-troubleshoot` (slash command)
 
 ---
 

--- a/qovery-troubleshoot/commands/qovery-troubleshoot.md
+++ b/qovery-troubleshoot/commands/qovery-troubleshoot.md
@@ -1,0 +1,14 @@
+---
+description: Troubleshoot a failing Qovery deployment or service
+---
+
+Troubleshoot and diagnose issues with a Qovery deployment or service.
+
+If arguments are provided, use them as context:
+- `$ARGUMENTS` — service name, error description, or Qovery Console URL
+
+Follow the qovery-troubleshoot skill to authenticate, identify the problem,
+run the 8-layer diagnostic workflow, and apply fixes.
+
+Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
+Git remote: !`git remote get-url origin 2>/dev/null || echo "unknown"`


### PR DESCRIPTION
## Summary

Add slash commands for all 6 Qovery skills, making them directly invocable from the AI tool's chat input.

## New Command Files

| Command | File | Description |
|---------|------|-------------|
| `/qovery-deploy` | `qovery-deploy/commands/qovery-deploy.md` | Deploy current project — auto-detects codebase (package.json, go.mod, etc.) |
| `/qovery-troubleshoot` | `qovery-troubleshoot/commands/qovery-troubleshoot.md` | Diagnose failing service — accepts service name or Console URL |
| `/qovery-onboard` | `qovery-onboard/commands/qovery-onboard.md` | Start guided onboarding — accepts role or migration source |
| `/qovery-speedup` | `qovery-speedup/commands/qovery-speedup.md` | Analyze deployment speed — accepts service/environment name |
| `/qovery-optimize` | `qovery-optimize/commands/qovery-optimize.md` | Optimize costs — accepts environment name or Console URL |

The `/qovery-preview` command was already created in PR #6.

## Modified Files

| File | Change |
|------|--------|
| `qovery-deploy/SKILL.md` | Added `/qovery-deploy` to "When to Use" trigger list |
| `qovery-troubleshoot/SKILL.md` | Added `/qovery-troubleshoot` to "When to Use" trigger list |
| `qovery-onboard/SKILL.md` | Added `/qovery-onboard` to "When to Use" trigger list |
| `qovery-speedup/SKILL.md` | Added `/qovery-speedup` to "When to Use" trigger list |
| `qovery-optimize/SKILL.md` | Added `/qovery-optimize` to "When to Use" trigger list |
| `README.md` | Added "Slash Commands" section with usage table and manual install instructions |

## How Commands Work

Each command:
- Accepts optional `$ARGUMENTS` (service name, environment name, Console URL, or free-text instructions)
- Auto-injects git context where relevant (current branch, remote URL, detected project files)
- Triggers the corresponding skill's full workflow

## Installation

The `install.sh` script already handles command installation generically (added in PR #6) — it scans all skills for `commands/` directories and copies them to the appropriate location. No changes to `install.sh` needed.

Commands are installed to:
- **Global**: `~/.config/opencode/commands/` (OpenCode), `~/.claude/commands/` (Claude Code), `~/.agents/commands/`
- **Project-local**: `.opencode/commands/`, `.claude/commands/`, `.agents/commands/`