### PR TITLE
Harden the authentication flow (prefer Qovery API over token creation)

### DIFF
--- a/_shared/auth.md
+++ b/_shared/auth.md
@@ -4,63 +4,68 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
+- When a long-lived token must be created, do NOT display the output. Pipe it directly into secure storage that the agent does not read.
 
-## 1. Existing API token in environment
+Skills authenticate using one of four tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Tier 3 — JWT fallback (restricted-role users)
+
+Some users (read-only, viewer, member roles) cannot create API tokens but are still authenticated through `qovery auth`. The CLI stores a short-lived JWT in `~/.qovery/context.json`. Use it inline so the value is not echoed:
+
+```bash
+[[ -s ~/.qovery/context.json ]] && echo "JWT available" || echo "no JWT"
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r '.access_token' ~/.qovery/context.json)" \
+  https://api.qovery.com/organization
+```
+
+JWTs expire quickly. Prefer Tier 1 for any non-trivial workflow — only use Tier 3 when the user lacks permission to create a token.
+
+## Tier 4 — Not authenticated
+
+If none of the above works, prompt the user to log in:
+
+```bash
+qovery auth                        # interactive browser login
+# OR for headless environments, the user sets:
+#   export QOVERY_CLI_ACCESS_TOKEN=qov_xxx
+```
+
+After login, fall through to Tier 1.

--- a/qovery-builder-env/reference/auth.md
+++ b/qovery-builder-env/reference/auth.md
@@ -4,63 +4,68 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
+- When a long-lived token must be created, do NOT display the output. Pipe it directly into secure storage that the agent does not read.
 
-## 1. Existing API token in environment
+Skills authenticate using one of four tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Tier 3 — JWT fallback (restricted-role users)
+
+Some users (read-only, viewer, member roles) cannot create API tokens but are still authenticated through `qovery auth`. The CLI stores a short-lived JWT in `~/.qovery/context.json`. Use it inline so the value is not echoed:
+
+```bash
+[[ -s ~/.qovery/context.json ]] && echo "JWT available" || echo "no JWT"
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r '.access_token' ~/.qovery/context.json)" \
+  https://api.qovery.com/organization
+```
+
+JWTs expire quickly. Prefer Tier 1 for any non-trivial workflow — only use Tier 3 when the user lacks permission to create a token.
+
+## Tier 4 — Not authenticated
+
+If none of the above works, prompt the user to log in:
+
+```bash
+qovery auth                        # interactive browser login
+# OR for headless environments, the user sets:
+#   export QOVERY_CLI_ACCESS_TOKEN=qov_xxx
+```
+
+After login, fall through to Tier 1.

--- a/qovery-builder-env/reference/phase1-requirements.md
+++ b/qovery-builder-env/reference/phase1-requirements.md
@@ -4,11 +4,7 @@ Before setting up anything, understand who the builders are, what they need, and
 
 ### 1.1 Authenticate
 
-Use the same authentication flow as the other Qovery skills:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set in the environment
-2. If not, try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed if expired). Use it directly with `Authorization: Bearer $(qovery auth token --print)` or generate a named API token via `qovery token create --name "builder-env-skill" --duration 24h`.
-3. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
-- Only ask the user to manually create a token at Qovery Console > Organization Settings > API Tokens if none of the above options work
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to the token / JWT / login tiers documented in the auth reference loaded with this skill.
 
 ### 1.2 Understand Who Will Build
 

--- a/qovery-builder-portal/reference/auth.md
+++ b/qovery-builder-portal/reference/auth.md
@@ -4,63 +4,68 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
+- When a long-lived token must be created, do NOT display the output. Pipe it directly into secure storage that the agent does not read.
 
-## 1. Existing API token in environment
+Skills authenticate using one of four tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Tier 3 — JWT fallback (restricted-role users)
+
+Some users (read-only, viewer, member roles) cannot create API tokens but are still authenticated through `qovery auth`. The CLI stores a short-lived JWT in `~/.qovery/context.json`. Use it inline so the value is not echoed:
+
+```bash
+[[ -s ~/.qovery/context.json ]] && echo "JWT available" || echo "no JWT"
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r '.access_token' ~/.qovery/context.json)" \
+  https://api.qovery.com/organization
+```
+
+JWTs expire quickly. Prefer Tier 1 for any non-trivial workflow — only use Tier 3 when the user lacks permission to create a token.
+
+## Tier 4 — Not authenticated
+
+If none of the above works, prompt the user to log in:
+
+```bash
+qovery auth                        # interactive browser login
+# OR for headless environments, the user sets:
+#   export QOVERY_CLI_ACCESS_TOKEN=qov_xxx
+```
+
+After login, fall through to Tier 1.

--- a/qovery-builder-portal/reference/phase1-requirements.md
+++ b/qovery-builder-portal/reference/phase1-requirements.md
@@ -2,10 +2,7 @@
 
 ### 1.1 Authenticate
 
-Use the same authentication flow as the other Qovery skills:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set in the environment
-2. If not, try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed if expired). Use it directly with `Authorization: Bearer $(qovery auth token --print)` or generate a named API token via `qovery token create --name "builder-portal" --duration 24h`.
-3. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to the token / JWT / login tiers documented in the auth reference loaded with this skill.
 
 ### 1.2 Check for Existing Builder-Env Setup
 

--- a/qovery-deploy/reference/auth.md
+++ b/qovery-deploy/reference/auth.md
@@ -4,63 +4,68 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
+- When a long-lived token must be created, do NOT display the output. Pipe it directly into secure storage that the agent does not read.
 
-## 1. Existing API token in environment
+Skills authenticate using one of four tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Tier 3 — JWT fallback (restricted-role users)
+
+Some users (read-only, viewer, member roles) cannot create API tokens but are still authenticated through `qovery auth`. The CLI stores a short-lived JWT in `~/.qovery/context.json`. Use it inline so the value is not echoed:
+
+```bash
+[[ -s ~/.qovery/context.json ]] && echo "JWT available" || echo "no JWT"
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r '.access_token' ~/.qovery/context.json)" \
+  https://api.qovery.com/organization
+```
+
+JWTs expire quickly. Prefer Tier 1 for any non-trivial workflow — only use Tier 3 when the user lacks permission to create a token.
+
+## Tier 4 — Not authenticated
+
+If none of the above works, prompt the user to log in:
+
+```bash
+qovery auth                        # interactive browser login
+# OR for headless environments, the user sets:
+#   export QOVERY_CLI_ACCESS_TOKEN=qov_xxx
+```
+
+After login, fall through to Tier 1.

--- a/qovery-deploy/reference/phase1-discovery.md
+++ b/qovery-deploy/reference/phase1-discovery.md
@@ -6,12 +6,7 @@ Before doing anything, you MUST gather information by asking the user these ques
 
 #### Step 1: Authenticate
 
-Before asking any questions, try to detect an existing token automatically:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set in the environment
-2. If not, try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed if expired). Use it directly with `Authorization: Bearer $(qovery auth token --print)` or generate a named API token via `qovery token create --name "deploy-skill" --duration 24h`.
-3. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
-- Only ask the user to manually create a token at Qovery Console > Organization Settings > API Tokens if none of the above options work
-- Tokens should be stored securely (never commit to git)
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to the token / JWT / login tiers documented in the auth reference loaded with this skill.
 
 #### Step 2: Resolve Organization
 

--- a/qovery-onboard/reference/auth.md
+++ b/qovery-onboard/reference/auth.md
@@ -4,63 +4,68 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
+- When a long-lived token must be created, do NOT display the output. Pipe it directly into secure storage that the agent does not read.
 
-## 1. Existing API token in environment
+Skills authenticate using one of four tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Tier 3 — JWT fallback (restricted-role users)
+
+Some users (read-only, viewer, member roles) cannot create API tokens but are still authenticated through `qovery auth`. The CLI stores a short-lived JWT in `~/.qovery/context.json`. Use it inline so the value is not echoed:
+
+```bash
+[[ -s ~/.qovery/context.json ]] && echo "JWT available" || echo "no JWT"
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r '.access_token' ~/.qovery/context.json)" \
+  https://api.qovery.com/organization
+```
+
+JWTs expire quickly. Prefer Tier 1 for any non-trivial workflow — only use Tier 3 when the user lacks permission to create a token.
+
+## Tier 4 — Not authenticated
+
+If none of the above works, prompt the user to log in:
+
+```bash
+qovery auth                        # interactive browser login
+# OR for headless environments, the user sets:
+#   export QOVERY_CLI_ACCESS_TOKEN=qov_xxx
+```
+
+After login, fall through to Tier 1.

--- a/qovery-optimize/reference/auth.md
+++ b/qovery-optimize/reference/auth.md
@@ -4,63 +4,68 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
+- When a long-lived token must be created, do NOT display the output. Pipe it directly into secure storage that the agent does not read.
 
-## 1. Existing API token in environment
+Skills authenticate using one of four tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Tier 3 — JWT fallback (restricted-role users)
+
+Some users (read-only, viewer, member roles) cannot create API tokens but are still authenticated through `qovery auth`. The CLI stores a short-lived JWT in `~/.qovery/context.json`. Use it inline so the value is not echoed:
+
+```bash
+[[ -s ~/.qovery/context.json ]] && echo "JWT available" || echo "no JWT"
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r '.access_token' ~/.qovery/context.json)" \
+  https://api.qovery.com/organization
+```
+
+JWTs expire quickly. Prefer Tier 1 for any non-trivial workflow — only use Tier 3 when the user lacks permission to create a token.
+
+## Tier 4 — Not authenticated
+
+If none of the above works, prompt the user to log in:
+
+```bash
+qovery auth                        # interactive browser login
+# OR for headless environments, the user sets:
+#   export QOVERY_CLI_ACCESS_TOKEN=qov_xxx
+```
+
+After login, fall through to Tier 1.

--- a/qovery-optimize/reference/phase1-context-gathering.md
+++ b/qovery-optimize/reference/phase1-context-gathering.md
@@ -6,11 +6,7 @@ Before optimizing, you MUST understand the business context. Blind optimization 
 
 **Shortcut:** If the user provided a Qovery Console URL, extract the organization ID and any other IDs from it using the URL Detection rules above. Use the extracted IDs to scope the inventory and cost analysis — e.g., if a specific environment ID is provided, focus the optimization on that environment's services rather than scanning the entire organization.
 
-Use the same authentication flow as the other Qovery skills:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set
-2. Try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed). Use with `Authorization: Bearer $(qovery auth token --print)`.
-3. Generate a named API token if needed: `qovery token create --name "optimize-skill" --duration 24h`
-4. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to the token / JWT / login tiers documented in the auth reference loaded with this skill.
 
 Then gather a complete inventory:
 

--- a/qovery-preview/reference/auth.md
+++ b/qovery-preview/reference/auth.md
@@ -4,63 +4,68 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
+- When a long-lived token must be created, do NOT display the output. Pipe it directly into secure storage that the agent does not read.
 
-## 1. Existing API token in environment
+Skills authenticate using one of four tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Tier 3 — JWT fallback (restricted-role users)
+
+Some users (read-only, viewer, member roles) cannot create API tokens but are still authenticated through `qovery auth`. The CLI stores a short-lived JWT in `~/.qovery/context.json`. Use it inline so the value is not echoed:
+
+```bash
+[[ -s ~/.qovery/context.json ]] && echo "JWT available" || echo "no JWT"
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r '.access_token' ~/.qovery/context.json)" \
+  https://api.qovery.com/organization
+```
+
+JWTs expire quickly. Prefer Tier 1 for any non-trivial workflow — only use Tier 3 when the user lacks permission to create a token.
+
+## Tier 4 — Not authenticated
+
+If none of the above works, prompt the user to log in:
+
+```bash
+qovery auth                        # interactive browser login
+# OR for headless environments, the user sets:
+#   export QOVERY_CLI_ACCESS_TOKEN=qov_xxx
+```
+
+After login, fall through to Tier 1.

--- a/qovery-preview/reference/phase1-context.md
+++ b/qovery-preview/reference/phase1-context.md
@@ -4,11 +4,7 @@ Before creating anything, gather all the information needed to build the preview
 
 ### 1.1 Authenticate
 
-Use the same authentication flow as the other Qovery skills:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set in the environment
-2. If not, try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed if expired). Use it directly with `Authorization: Bearer $(qovery auth token --print)` or generate a named API token via `qovery token create --name "preview-skill" --duration 24h`.
-3. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
-- Only ask the user to manually create a token at Qovery Console > Organization Settings > API Tokens if none of the above options work
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to the token / JWT / login tiers documented in the auth reference loaded with this skill.
 
 ### 1.2 Detect PR / Branch Context
 

--- a/qovery-speedup/reference/auth.md
+++ b/qovery-speedup/reference/auth.md
@@ -4,63 +4,68 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
+- When a long-lived token must be created, do NOT display the output. Pipe it directly into secure storage that the agent does not read.
 
-## 1. Existing API token in environment
+Skills authenticate using one of four tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Tier 3 — JWT fallback (restricted-role users)
+
+Some users (read-only, viewer, member roles) cannot create API tokens but are still authenticated through `qovery auth`. The CLI stores a short-lived JWT in `~/.qovery/context.json`. Use it inline so the value is not echoed:
+
+```bash
+[[ -s ~/.qovery/context.json ]] && echo "JWT available" || echo "no JWT"
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r '.access_token' ~/.qovery/context.json)" \
+  https://api.qovery.com/organization
+```
+
+JWTs expire quickly. Prefer Tier 1 for any non-trivial workflow — only use Tier 3 when the user lacks permission to create a token.
+
+## Tier 4 — Not authenticated
+
+If none of the above works, prompt the user to log in:
+
+```bash
+qovery auth                        # interactive browser login
+# OR for headless environments, the user sets:
+#   export QOVERY_CLI_ACCESS_TOKEN=qov_xxx
+```
+
+After login, fall through to Tier 1.

--- a/qovery-troubleshoot/reference/auth.md
+++ b/qovery-troubleshoot/reference/auth.md
@@ -4,63 +4,68 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
+- When a long-lived token must be created, do NOT display the output. Pipe it directly into secure storage that the agent does not read.
 
-## 1. Existing API token in environment
+Skills authenticate using one of four tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Tier 3 — JWT fallback (restricted-role users)
+
+Some users (read-only, viewer, member roles) cannot create API tokens but are still authenticated through `qovery auth`. The CLI stores a short-lived JWT in `~/.qovery/context.json`. Use it inline so the value is not echoed:
+
+```bash
+[[ -s ~/.qovery/context.json ]] && echo "JWT available" || echo "no JWT"
+```
+
+```bash
+curl -s -H "Authorization: Bearer $(jq -r '.access_token' ~/.qovery/context.json)" \
+  https://api.qovery.com/organization
+```
+
+JWTs expire quickly. Prefer Tier 1 for any non-trivial workflow — only use Tier 3 when the user lacks permission to create a token.
+
+## Tier 4 — Not authenticated
+
+If none of the above works, prompt the user to log in:
+
+```bash
+qovery auth                        # interactive browser login
+# OR for headless environments, the user sets:
+#   export QOVERY_CLI_ACCESS_TOKEN=qov_xxx
+```
+
+After login, fall through to Tier 1.

--- a/qovery-troubleshoot/reference/phase1-context-gathering.md
+++ b/qovery-troubleshoot/reference/phase1-context-gathering.md
@@ -4,11 +4,7 @@ Before diagnosing anything, you MUST understand what's deployed and what the use
 
 ### 1.1 Authenticate
 
-Use the same authentication flow as the deploy skill:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set
-2. Try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed). Use with `Authorization: Bearer $(qovery auth token --print)`.
-3. Generate a named API token if needed: `qovery token create --name "troubleshoot-skill" --duration 24h`
-4. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to the token / JWT / login tiers documented in the auth reference loaded with this skill.
 
 ### 1.2 Get Overview of All Services
 


### PR DESCRIPTION
## Outcomes

Eliminates token exposure risk and aligns the auth flow with how the Qovery CLI actually works: `qovery api /organization` already carries the user's session, so there is no need to create a named token during skill execution. Skills now work cleanly for users with restricted roles who cannot create tokens.

## Preview

**Before:**

The skill tries to read the tokens right from the environment, exposing the token into the LLM context.

<img width="1242" height="864" alt="image" src="https://github.com/user-attachments/assets/d1474953-ea02-4cc7-9ab4-d7a1a7c29e1e" />

**After:**

We rely exclusively on the `qovery` CLI, not exposing anything to the LLM.

<img width="1218" height="942" alt="image" src="https://github.com/user-attachments/assets/25643cf0-55e8-44df-96ea-c9b9eea97d0b" />

## Technical Changes

- **Tier ordering reworked** in `_shared/auth.md` and all synced copies: CLI (`qovery api`) → env token → JWT fallback → interactive login
- **Auth check changed** from `qovery context` to `qovery api /organization` — a real API round-trip that confirms the CLI is authenticated and reachable
- **Token creation step removed** — avoids printing a secret into the agent context and breaks the flow for restricted-role users
- **JWT restored as Tier 3** (not removed) for users who cannot create tokens but have a CLI context
- **Phase 1 files** across all skills now reference `reference/auth.md` instead of repeating inline auth steps