### PR TITLE
Harden auth flow: prefer qovery api, never let the agent handle tokens

### DIFF
--- a/_shared/auth.md
+++ b/_shared/auth.md
@@ -4,63 +4,64 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- NEVER run `qovery token create` yourself — the command prints the new token to stdout. Ask the user to run it themselves and export the result. See "Not authenticated" below.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
 
-## 1. Existing API token in environment
+Skills authenticate using one of two tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Not authenticated — ask the user
+
+If neither tier works, do **not** generate a token from inside the agent. Instead, instruct the user to run one of these themselves so the secret never enters the agent's command stream:
+
+**Option A — interactive login (recommended).** Falls back to Tier 1:
+
+```bash
+qovery auth        # opens a browser; the agent never sees the credential
+```
+
+After login, retry Tier 1.
+
+**Option B — long-lived API token.** The user runs this in their own shell and exports the result. The agent does not run `qovery token create` and does not read the output:
+
+```bash
+# User runs this manually, NOT the agent:
+qovery token create --name "skill-$(date +%Y%m%d)" --duration 24h
+# Then the user copies the printed token into a secure store and exports it:
+export QOVERY_API_TOKEN=qov_xxx
+```
+
+After the user exports the token in the shell that runs the skill, retry Tier 2.

--- a/qovery-builder-env/reference/auth.md
+++ b/qovery-builder-env/reference/auth.md
@@ -4,63 +4,64 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- NEVER run `qovery token create` yourself — the command prints the new token to stdout. Ask the user to run it themselves and export the result. See "Not authenticated" below.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
 
-## 1. Existing API token in environment
+Skills authenticate using one of two tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Not authenticated — ask the user
+
+If neither tier works, do **not** generate a token from inside the agent. Instead, instruct the user to run one of these themselves so the secret never enters the agent's command stream:
+
+**Option A — interactive login (recommended).** Falls back to Tier 1:
+
+```bash
+qovery auth        # opens a browser; the agent never sees the credential
+```
+
+After login, retry Tier 1.
+
+**Option B — long-lived API token.** The user runs this in their own shell and exports the result. The agent does not run `qovery token create` and does not read the output:
+
+```bash
+# User runs this manually, NOT the agent:
+qovery token create --name "skill-$(date +%Y%m%d)" --duration 24h
+# Then the user copies the printed token into a secure store and exports it:
+export QOVERY_API_TOKEN=qov_xxx
+```
+
+After the user exports the token in the shell that runs the skill, retry Tier 2.

--- a/qovery-builder-env/reference/phase1-requirements.md
+++ b/qovery-builder-env/reference/phase1-requirements.md
@@ -4,11 +4,7 @@ Before setting up anything, understand who the builders are, what they need, and
 
 ### 1.1 Authenticate
 
-Use the same authentication flow as the other Qovery skills:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set in the environment
-2. If not, try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed if expired). Use it directly with `Authorization: Bearer $(qovery auth token --print)` or generate a named API token via `qovery token create --name "builder-env-skill" --duration 24h`.
-3. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
-- Only ask the user to manually create a token at Qovery Console > Organization Settings > API Tokens if none of the above options work
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to `$QOVERY_API_TOKEN` with `curl`, or ask the user to run `qovery auth` (or create a token themselves and export it). See the auth reference loaded with this skill for details.
 
 ### 1.2 Understand Who Will Build
 

--- a/qovery-builder-portal/reference/auth.md
+++ b/qovery-builder-portal/reference/auth.md
@@ -4,63 +4,64 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- NEVER run `qovery token create` yourself — the command prints the new token to stdout. Ask the user to run it themselves and export the result. See "Not authenticated" below.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
 
-## 1. Existing API token in environment
+Skills authenticate using one of two tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Not authenticated — ask the user
+
+If neither tier works, do **not** generate a token from inside the agent. Instead, instruct the user to run one of these themselves so the secret never enters the agent's command stream:
+
+**Option A — interactive login (recommended).** Falls back to Tier 1:
+
+```bash
+qovery auth        # opens a browser; the agent never sees the credential
+```
+
+After login, retry Tier 1.
+
+**Option B — long-lived API token.** The user runs this in their own shell and exports the result. The agent does not run `qovery token create` and does not read the output:
+
+```bash
+# User runs this manually, NOT the agent:
+qovery token create --name "skill-$(date +%Y%m%d)" --duration 24h
+# Then the user copies the printed token into a secure store and exports it:
+export QOVERY_API_TOKEN=qov_xxx
+```
+
+After the user exports the token in the shell that runs the skill, retry Tier 2.

--- a/qovery-builder-portal/reference/phase1-requirements.md
+++ b/qovery-builder-portal/reference/phase1-requirements.md
@@ -2,10 +2,7 @@
 
 ### 1.1 Authenticate
 
-Use the same authentication flow as the other Qovery skills:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set in the environment
-2. If not, try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed if expired). Use it directly with `Authorization: Bearer $(qovery auth token --print)` or generate a named API token via `qovery token create --name "builder-portal" --duration 24h`.
-3. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to `$QOVERY_API_TOKEN` with `curl`, or ask the user to run `qovery auth` (or create a token themselves and export it). See the auth reference loaded with this skill for details.
 
 ### 1.2 Check for Existing Builder-Env Setup
 

--- a/qovery-deploy/reference/auth.md
+++ b/qovery-deploy/reference/auth.md
@@ -4,63 +4,64 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- NEVER run `qovery token create` yourself — the command prints the new token to stdout. Ask the user to run it themselves and export the result. See "Not authenticated" below.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
 
-## 1. Existing API token in environment
+Skills authenticate using one of two tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Not authenticated — ask the user
+
+If neither tier works, do **not** generate a token from inside the agent. Instead, instruct the user to run one of these themselves so the secret never enters the agent's command stream:
+
+**Option A — interactive login (recommended).** Falls back to Tier 1:
+
+```bash
+qovery auth        # opens a browser; the agent never sees the credential
+```
+
+After login, retry Tier 1.
+
+**Option B — long-lived API token.** The user runs this in their own shell and exports the result. The agent does not run `qovery token create` and does not read the output:
+
+```bash
+# User runs this manually, NOT the agent:
+qovery token create --name "skill-$(date +%Y%m%d)" --duration 24h
+# Then the user copies the printed token into a secure store and exports it:
+export QOVERY_API_TOKEN=qov_xxx
+```
+
+After the user exports the token in the shell that runs the skill, retry Tier 2.

--- a/qovery-deploy/reference/phase1-discovery.md
+++ b/qovery-deploy/reference/phase1-discovery.md
@@ -6,12 +6,7 @@ Before doing anything, you MUST gather information by asking the user these ques
 
 #### Step 1: Authenticate
 
-Before asking any questions, try to detect an existing token automatically:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set in the environment
-2. If not, try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed if expired). Use it directly with `Authorization: Bearer $(qovery auth token --print)` or generate a named API token via `qovery token create --name "deploy-skill" --duration 24h`.
-3. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
-- Only ask the user to manually create a token at Qovery Console > Organization Settings > API Tokens if none of the above options work
-- Tokens should be stored securely (never commit to git)
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to `$QOVERY_API_TOKEN` with `curl`, or ask the user to run `qovery auth` (or create a token themselves and export it). See the auth reference loaded with this skill for details.
 
 #### Step 2: Resolve Organization
 

--- a/qovery-onboard/reference/auth.md
+++ b/qovery-onboard/reference/auth.md
@@ -4,63 +4,64 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- NEVER run `qovery token create` yourself — the command prints the new token to stdout. Ask the user to run it themselves and export the result. See "Not authenticated" below.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
 
-## 1. Existing API token in environment
+Skills authenticate using one of two tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Not authenticated — ask the user
+
+If neither tier works, do **not** generate a token from inside the agent. Instead, instruct the user to run one of these themselves so the secret never enters the agent's command stream:
+
+**Option A — interactive login (recommended).** Falls back to Tier 1:
+
+```bash
+qovery auth        # opens a browser; the agent never sees the credential
+```
+
+After login, retry Tier 1.
+
+**Option B — long-lived API token.** The user runs this in their own shell and exports the result. The agent does not run `qovery token create` and does not read the output:
+
+```bash
+# User runs this manually, NOT the agent:
+qovery token create --name "skill-$(date +%Y%m%d)" --duration 24h
+# Then the user copies the printed token into a secure store and exports it:
+export QOVERY_API_TOKEN=qov_xxx
+```
+
+After the user exports the token in the shell that runs the skill, retry Tier 2.

--- a/qovery-optimize/reference/auth.md
+++ b/qovery-optimize/reference/auth.md
@@ -4,63 +4,64 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- NEVER run `qovery token create` yourself — the command prints the new token to stdout. Ask the user to run it themselves and export the result. See "Not authenticated" below.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
 
-## 1. Existing API token in environment
+Skills authenticate using one of two tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Not authenticated — ask the user
+
+If neither tier works, do **not** generate a token from inside the agent. Instead, instruct the user to run one of these themselves so the secret never enters the agent's command stream:
+
+**Option A — interactive login (recommended).** Falls back to Tier 1:
+
+```bash
+qovery auth        # opens a browser; the agent never sees the credential
+```
+
+After login, retry Tier 1.
+
+**Option B — long-lived API token.** The user runs this in their own shell and exports the result. The agent does not run `qovery token create` and does not read the output:
+
+```bash
+# User runs this manually, NOT the agent:
+qovery token create --name "skill-$(date +%Y%m%d)" --duration 24h
+# Then the user copies the printed token into a secure store and exports it:
+export QOVERY_API_TOKEN=qov_xxx
+```
+
+After the user exports the token in the shell that runs the skill, retry Tier 2.

--- a/qovery-optimize/reference/phase1-context-gathering.md
+++ b/qovery-optimize/reference/phase1-context-gathering.md
@@ -6,11 +6,7 @@ Before optimizing, you MUST understand the business context. Blind optimization 
 
 **Shortcut:** If the user provided a Qovery Console URL, extract the organization ID and any other IDs from it using the URL Detection rules above. Use the extracted IDs to scope the inventory and cost analysis — e.g., if a specific environment ID is provided, focus the optimization on that environment's services rather than scanning the entire organization.
 
-Use the same authentication flow as the other Qovery skills:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set
-2. Try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed). Use with `Authorization: Bearer $(qovery auth token --print)`.
-3. Generate a named API token if needed: `qovery token create --name "optimize-skill" --duration 24h`
-4. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to `$QOVERY_API_TOKEN` with `curl`, or ask the user to run `qovery auth` (or create a token themselves and export it). See the auth reference loaded with this skill for details.
 
 Then gather a complete inventory:
 

--- a/qovery-preview/reference/auth.md
+++ b/qovery-preview/reference/auth.md
@@ -4,63 +4,64 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- NEVER run `qovery token create` yourself — the command prints the new token to stdout. Ask the user to run it themselves and export the result. See "Not authenticated" below.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
 
-## 1. Existing API token in environment
+Skills authenticate using one of two tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Not authenticated — ask the user
+
+If neither tier works, do **not** generate a token from inside the agent. Instead, instruct the user to run one of these themselves so the secret never enters the agent's command stream:
+
+**Option A — interactive login (recommended).** Falls back to Tier 1:
+
+```bash
+qovery auth        # opens a browser; the agent never sees the credential
+```
+
+After login, retry Tier 1.
+
+**Option B — long-lived API token.** The user runs this in their own shell and exports the result. The agent does not run `qovery token create` and does not read the output:
+
+```bash
+# User runs this manually, NOT the agent:
+qovery token create --name "skill-$(date +%Y%m%d)" --duration 24h
+# Then the user copies the printed token into a secure store and exports it:
+export QOVERY_API_TOKEN=qov_xxx
+```
+
+After the user exports the token in the shell that runs the skill, retry Tier 2.

--- a/qovery-preview/reference/phase1-context.md
+++ b/qovery-preview/reference/phase1-context.md
@@ -4,11 +4,7 @@ Before creating anything, gather all the information needed to build the preview
 
 ### 1.1 Authenticate
 
-Use the same authentication flow as the other Qovery skills:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set in the environment
-2. If not, try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed if expired). Use it directly with `Authorization: Bearer $(qovery auth token --print)` or generate a named API token via `qovery token create --name "preview-skill" --duration 24h`.
-3. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
-- Only ask the user to manually create a token at Qovery Console > Organization Settings > API Tokens if none of the above options work
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to `$QOVERY_API_TOKEN` with `curl`, or ask the user to run `qovery auth` (or create a token themselves and export it). See the auth reference loaded with this skill for details.
 
 ### 1.2 Detect PR / Branch Context
 

--- a/qovery-speedup/reference/auth.md
+++ b/qovery-speedup/reference/auth.md
@@ -4,63 +4,64 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- NEVER run `qovery token create` yourself — the command prints the new token to stdout. Ask the user to run it themselves and export the result. See "Not authenticated" below.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
 
-## 1. Existing API token in environment
+Skills authenticate using one of two tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Not authenticated — ask the user
+
+If neither tier works, do **not** generate a token from inside the agent. Instead, instruct the user to run one of these themselves so the secret never enters the agent's command stream:
+
+**Option A — interactive login (recommended).** Falls back to Tier 1:
+
+```bash
+qovery auth        # opens a browser; the agent never sees the credential
+```
+
+After login, retry Tier 1.
+
+**Option B — long-lived API token.** The user runs this in their own shell and exports the result. The agent does not run `qovery token create` and does not read the output:
+
+```bash
+# User runs this manually, NOT the agent:
+qovery token create --name "skill-$(date +%Y%m%d)" --duration 24h
+# Then the user copies the printed token into a secure store and exports it:
+export QOVERY_API_TOKEN=qov_xxx
+```
+
+After the user exports the token in the shell that runs the skill, retry Tier 2.

--- a/qovery-troubleshoot/reference/auth.md
+++ b/qovery-troubleshoot/reference/auth.md
@@ -4,63 +4,64 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
-  ```bash
-  # CORRECT — token is inline, never shown:
-  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
-
-  # WRONG — token value would appear in output:
-  qovery auth token --print
-  echo $(qovery auth token --print)
-  export TOKEN=$(qovery auth token --print)
-  ```
 - NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
 - NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
 - NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
 - NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
-- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
-- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+- NEVER run `qovery token create` yourself — the command prints the new token to stdout. Ask the user to run it themselves and export the result. See "Not authenticated" below.
+- Prefer the `qovery` CLI (e.g., `qovery api`, `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens — the CLI authenticates internally without exposing tokens
 
-## 1. Existing API token in environment
+Skills authenticate using one of two tiers, checked in order. Stop at the first one that works.
 
-```bash
-# Check if a token is available (without printing it):
-test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
-```
+## Tier 1 — `qovery api` (preferred)
 
-If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
-
-## 2. CLI already authenticated (`qovery auth token`)
+If the `qovery` CLI is installed and authenticated, use it directly for every API call. No token needs to be extracted, printed, or stored:
 
 ```bash
-# Check if the CLI is authenticated (without printing the token):
-qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+qovery api /organization                           # confirms auth + lists orgs
+qovery api /environment/{envId}/status
+qovery api /organization/{orgId}/cluster
 ```
 
-If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+Detect availability without revealing any secret:
 
 ```bash
-# Token flows through the shell but is never visible to the agent:
-curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+qovery api /organization >/dev/null 2>&1 && echo "qovery api OK" || echo "qovery api unavailable"
 ```
 
-Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+If this tier works, **use it for all API calls in the skill**. Skip the rest.
+
+## Tier 2 — Token in environment
+
+If `qovery api` is unavailable but a token is already exported in the shell, use it directly with `curl`. The env var is expanded by the shell at execution time, so the agent never sees the value:
 
 ```bash
-# Create the token and store it directly in .env (not displayed):
-qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
-# The user should manually export it or add it to their secure env config
-echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+[[ -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" ]] && echo SET || echo "NOT SET"
 ```
-
-## 3. Interactive login
-
-If neither of the above works, prompt the user:
 
 ```bash
-qovery auth                      # interactive browser login
-# OR for headless:
-# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" https://api.qovery.com/organization
 ```
 
-After login, fall through to step 2 to obtain a token.
+## Not authenticated — ask the user
+
+If neither tier works, do **not** generate a token from inside the agent. Instead, instruct the user to run one of these themselves so the secret never enters the agent's command stream:
+
+**Option A — interactive login (recommended).** Falls back to Tier 1:
+
+```bash
+qovery auth        # opens a browser; the agent never sees the credential
+```
+
+After login, retry Tier 1.
+
+**Option B — long-lived API token.** The user runs this in their own shell and exports the result. The agent does not run `qovery token create` and does not read the output:
+
+```bash
+# User runs this manually, NOT the agent:
+qovery token create --name "skill-$(date +%Y%m%d)" --duration 24h
+# Then the user copies the printed token into a secure store and exports it:
+export QOVERY_API_TOKEN=qov_xxx
+```
+
+After the user exports the token in the shell that runs the skill, retry Tier 2.

--- a/qovery-troubleshoot/reference/phase1-context-gathering.md
+++ b/qovery-troubleshoot/reference/phase1-context-gathering.md
@@ -4,11 +4,7 @@ Before diagnosing anything, you MUST understand what's deployed and what the use
 
 ### 1.1 Authenticate
 
-Use the same authentication flow as the deploy skill:
-1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set
-2. Try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed). Use with `Authorization: Bearer $(qovery auth token --print)`.
-3. Generate a named API token if needed: `qovery token create --name "troubleshoot-skill" --duration 24h`
-4. If the CLI is not authenticated, run `qovery auth` for interactive login, then use step 2.
+Run `qovery api /organization` to confirm the CLI is authenticated. If it succeeds, use `qovery api` for every API call in this skill (no token needs to be extracted). If it fails, fall back to `$QOVERY_API_TOKEN` with `curl`, or ask the user to run `qovery auth` (or create a token themselves and export it). See the auth reference loaded with this skill for details.
 
 ### 1.2 Get Overview of All Services
 


### PR DESCRIPTION
## Outcomes

Removes every code path where the agent could see, capture, or generate a Qovery token. Skills now authenticate through the `qovery` CLI, which keeps secrets out of the agent's command stream.

User impact:
- AI agents running these skills no longer need an API token to be created or printed in the conversation.
- Restricted-role users (read-only / viewer / member) can use the skills after `qovery auth` without any token-creation step.
- When a token is genuinely required, the **user** runs the command and exports it — the agent is not in the loop.

## Technical Changes

- Adds Tier 1 `qovery api` as the preferred auth path (CLI handles auth internally — no token in the agent's stream).
- Drops the `qovery auth token --print` flow that piped the CLI bearer token into `curl`.
- Drops the agent-run `qovery token create` suggestion (its stdout exposes the token).
- "Not authenticated" path now instructs the user to run `qovery auth` (browser login) or `qovery token create` themselves.
- Replaces inline auth steps in 6 phase1 files with a brief `qovery api` reminder; full flow stays in `_shared/auth.md`, synced to all 8 skills.