### PR TITLE
feat(QOV-1981): add a call to the skills tracking

### DIFF
--- a/qovery-deploy/SKILL.md
+++ b/qovery-deploy/SKILL.md
@@ -12,6 +12,21 @@ metadata:
 
 This skill deploys applications to Kubernetes via Qovery. It analyzes the project, asks the right questions, prepares prerequisites (including creating a Dockerfile if missing), and deploys using either the Qovery CLI + API or the Qovery Terraform provider.
 
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
+
+```bash
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery-deploy"
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-deploy (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
 ## When to Use This Skill
 
 Trigger phrases:

--- a/qovery-onboard/SKILL.md
+++ b/qovery-onboard/SKILL.md
@@ -14,6 +14,21 @@ This skill guides new Qovery users through a complete, best-practice setup — w
 
 The skill is opinionated: it does NOT dump configuration options on the user. It UNDERSTANDS the user's context and MAKES DECISIONS for them, with smart defaults that encode security, cost, and operational best practices. The user can override anything, but the defaults are excellent by design.
 
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
+
+```bash
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery-onboard"
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-onboard (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
 ## When to Use This Skill
 
 Trigger phrases:

--- a/qovery-optimize/SKILL.md
+++ b/qovery-optimize/SKILL.md
@@ -19,6 +19,21 @@ It is NOT about blindly reducing everything to minimum. It is **intelligent opti
 - Estimates external cloud resource costs from public pricing data
 - Presents recommendations with expected savings AND risks
 
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
+
+```bash
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery-optimize"
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-optimize (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
 ## When to Use This Skill
 
 Trigger phrases:

--- a/qovery-preview/SKILL.md
+++ b/qovery-preview/SKILL.md
@@ -12,6 +12,21 @@ metadata:
 
 This skill creates preview environments on Kubernetes via Qovery. It detects PR/branch context, finds or creates a blueprint environment, clones it, switches branches, configures auto-shutdown, and deploys.
 
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
+
+```bash
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery-preview"
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-preview (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
 ## When to Use This Skill
 
 Trigger phrases:

--- a/qovery-speedup/SKILL.md
+++ b/qovery-speedup/SKILL.md
@@ -14,6 +14,21 @@ This skill speeds up Qovery deployments. It measures exactly where time is being
 
 For deployment failures use `qovery-troubleshoot`. For cost optimization use `qovery-optimize`.
 
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
+
+```bash
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery-speedup"
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-speedup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
 ## When to Use This Skill
 
 Trigger phrases:

--- a/qovery-terraform/SKILL.md
+++ b/qovery-terraform/SKILL.md
@@ -14,6 +14,21 @@ Generates Terraform manifests from an existing Qovery setup — reads the curren
 
 Supports single environments or multiple environments merged into one configuration.
 
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
+
+```bash
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery-terraform"
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-terraform (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
 ## CRITICAL SAFETY RULES
 
 > **NEVER run `terraform apply` on the original environment without explicit user confirmation.**

--- a/qovery-troubleshoot/SKILL.md
+++ b/qovery-troubleshoot/SKILL.md
@@ -14,6 +14,21 @@ This skill diagnoses and fixes infrastructure and application issues on Qovery â
 
 For slow-but-working deployments use `qovery-speedup`. For cost-driven optimization use `qovery-optimize`.
 
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND IMMEDIATELY â€” before any other action. Do not skip.**
+
+```bash
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery-troubleshoot"
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-troubleshoot (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
 ## When to Use This Skill
 
 Trigger phrases:

--- a/qovery/SKILL.md
+++ b/qovery/SKILL.md
@@ -29,6 +29,21 @@ Activate when the user mentions Qovery generically or needs a quick operation:
 
 Do NOT use this skill if the user's intent clearly matches a specialized skill — use that skill directly.
 
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
+
+```bash
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery"
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
 ---
 
 ## Qovery Console URL Detection


### PR DESCRIPTION
## Summary

Adds a usage tracking beacon to all 8 skills. Each skill now calls the skill tracking endpoint that stores a PostHog event, enabling us to measure which skills are used in production

## Changes

**Edited (8 files):**
- qovery/SKILL.md : added usage Tracking section
- qovery-deploy/SKILL.md : added usage Tracking section
- qovery-onboard/SKILL.md : added usage Tracking section
- qovery-optimize/SKILL.md : added usage Tracking section
- qovery-preview/SKILL.md : added usage Tracking section
- qovery-speedup/SKILL.md : added usage Tracking section
- qovery-terraform/SKILL.md : added usage Tracking section
- qovery-troubleshoot/SKILL.md : added usage Tracking section

## Verification

- All SKILL.md files under 500 lines ✓
- All internal links resolve ✓
- No anti-patterns found ✓
- Tracking call is non-blocking (|| true) and silent (> /dev/null 2>&1) ✓
- Org ID fetched dynamically via GET /organization ✓
- Token uses $QOVERY_API_TOKEN env var inline ✓