### PR TITLE
feat(troubleshoot): rely on MCP first to have clean data and integration

### DIFF
--- a/qovery-troubleshoot/SKILL.md
+++ b/qovery-troubleshoot/SKILL.md
@@ -63,7 +63,7 @@ Troubleshooting Progress:
 |---|---|---|
 | Console URL | [reference/console-url-detection.md](reference/console-url-detection.md) | Extract IDs from a Qovery Console URL |
 | Auth | [reference/auth.md](reference/auth.md) | API token flow |
-| MCP | [reference/mcp-server-integration.md](reference/mcp-server-integration.md) | When to prefer MCP over CLI/API; how to set up MCP |
+| MCP | [reference/mcp-server-integration.md](reference/mcp-server-integration.md) | Primary interface: the Qovery MCP tools, each mapped to the curl it replaces; setup |
 | Phase 1 | [reference/phase1-context-gathering.md](reference/phase1-context-gathering.md) | Service inventory, problem identification, log fetching |
 | Phase 2 | [reference/phase2-8-layer-diagnosis.md](reference/phase2-8-layer-diagnosis.md) | Cluster → Kubernetes → image → container → app → connectivity → config → cost |
 | Phase 3 | [reference/phase3-playbooks.md](reference/phase3-playbooks.md) | Build failure, OOM, port mismatch, health check, stuck deploy, DB connectivity, etc. |
@@ -87,39 +87,35 @@ When triaging an issue, walk top-down through these layers in [reference/phase2-
 
 ## Quick reference
 
-### MCP queries
+### MCP tools (primary interface)
+
+Prefer these Qovery MCP tools over CLI/API for every step. Resolve IDs top-down, then act. See [reference/mcp-server-integration.md](reference/mcp-server-integration.md) for full parameters and the tool→curl mapping.
 
 ```
-# Status & Health
-"Is everything healthy?"
-"Show failing services"
-"What's the status of all services?"
-"Is the cluster healthy?"
+# Resolve IDs (org → project → environment → service)
+list_organizations()
+list_projects(organization_id)
+list_environments(project_id)
+list_services(environment_id)                 # every service + its state
 
-# Logs & Diagnostics
-"Show error logs from the last hour for {service}"
-"Why is my deployment failing?"
-"Analyze failed build logs for {service}"
-"Why is the health check failing?"
+# Logs (any service type: app, container, job, database, helm)
+get_service_logs(environment_id, service_id[, deployment_id, pod_name])
 
-# Connectivity
-"Why can't my app connect to the database?"
-"Is the database running?"
-"Show database connection info"
+# Kubernetes-level health & events
+get_cluster_status(cluster_id, category)      # pod | node | networking | certificate | storage
+get_cluster_events(cluster_id, from_datetime, to_datetime[, pod_filter])
 
-# Resources
-"Show CPU usage across all services"
-"Why is my service out of memory?"
-
-# Actions
-"Restart the API service"
-"Redeploy the backend"
-"Cancel the ongoing deployment"
-"Scale the API to 5 replicas"
-"Rollback the API to previous version"
+# Everything else — config reads, deployment diagnosis, and fixes (reference resources by UUID):
+devops_copilot(organization_id, message[, project_id, environment_id, thread_id])
+#   READ        : status, config, env vars, health checks, custom domains, db/cluster settings
+#   TROUBLESHOOT: diagnose a failing/stuck deployment; which service caused a failure
+#   WRITE       : deploy/redeploy/stop/restart/scale; update cpu/memory/env vars/health checks;
+#                 reorder deployment stages; add/remove custom domain; cancel a deployment
 ```
 
-### CLI commands
+> Phase 4's auto-fix vs. ask-first rules govern every WRITE — using `devops_copilot` to apply a change does not bypass them.
+
+### CLI commands (fallback — when MCP is not configured)
 
 ```bash
 # Context and status
@@ -148,7 +144,9 @@ qovery shell --service "name"
 qovery cluster list
 ```
 
-### API endpoints
+### API endpoints (fallback — when MCP and CLI are unavailable)
+
+Each endpoint below has an MCP equivalent (see the tool→curl mapping in [reference/mcp-server-integration.md](reference/mcp-server-integration.md)); use these only when the MCP Server is not configured.
 
 ```
 # Base URL: https://api.qovery.com   Auth: Authorization: Token $QOVERY_API_TOKEN

--- a/qovery-troubleshoot/reference/mcp-server-integration.md
+++ b/qovery-troubleshoot/reference/mcp-server-integration.md
@@ -1,16 +1,76 @@
 ## MCP Server Integration
 
-This skill is designed to work with the **Qovery MCP Server** as the primary diagnostic interface. The MCP Server provides faster, more structured responses than raw CLI/API calls and is optimized for troubleshooting.
+This skill is designed to work with the **Qovery MCP Server** as the primary diagnostic and remediation interface. The MCP Server exposes structured tools that are faster and more reliable than raw CLI/API calls, and it handles authentication for you — no tokens flow through the shell.
 
-**If the Qovery MCP Server is available** (configured in the agent's MCP settings), prefer it for all queries. Use natural language prompts — the MCP Server understands context and returns structured, actionable data.
+**If the Qovery MCP Server is available** (configured in the agent's MCP settings), use its tools for every step: context gathering, diagnosis, and applying fixes. Prefer the MCP tools over `qovery` CLI commands and over `curl` against `api.qovery.com`.
 
-**If the MCP Server is NOT available**, fall back to the Qovery CLI and REST API. Every diagnostic step in this skill lists all three options: MCP query, CLI command, and API endpoint.
+**If the MCP Server is NOT available**, fall back to the Qovery CLI, and then to the REST API via `curl`. Every diagnostic step in this skill lists all three tiers in priority order: **MCP tool → CLI command → API endpoint**.
 
-### How to check if MCP Server is available
+### How to check if the MCP Server is available
 
-The MCP Server is available if the agent has it configured at `https://mcp.qovery.com/mcp`. Check by attempting a simple query like "Show me all environments." If it works, prefer MCP for all subsequent queries.
+The MCP Server is available if the agent has it configured at `https://mcp.qovery.com/mcp`. Check by calling `list_organizations` (or attempting any read tool). If the tool resolves, prefer MCP for all subsequent steps. If the tool is not present, use the CLI/API fallbacks.
 
-### MCP Server Setup (if not configured)
+---
+
+## MCP tools reference
+
+These are the tools the Qovery MCP Server exposes. They are the primary interface for this skill — reach for them before CLI or `curl`.
+
+### Resolution & inventory (READ)
+
+| Tool | Parameters | Use it to | Replaces |
+|---|---|---|---|
+| `list_organizations` | — | List organizations the token can access | `GET /organization` |
+| `list_projects` | `organization_id` | List projects in an organization | `GET /organization/{orgId}/project` |
+| `list_environments` | `project_id` | List environments in a project | `GET /project/{projectId}/environment` |
+| `list_services` | `environment_id` | List every service (app, container, job, database, helm, terraform) in an environment **with its state** | `GET /environment/{envId}/statuses` |
+
+Chain these to resolve IDs top-down (org → project → environment → service) when you don't already have them from a Console URL.
+
+### Logs (READ)
+
+| Tool | Parameters | Use it to | Replaces |
+|---|---|---|---|
+| `get_service_logs` | `environment_id`, `service_id`, optional `deployment_id`, optional `pod_name` | Fetch runtime/build logs for a service of **any** type — application, container, job, database, helm | `GET /application/{id}/log`, `GET /container/{id}/log`, and covers the job/database/helm cases the API has no endpoint for |
+
+`get_service_logs` supersedes both the per-type `curl` log endpoints and the `qovery log` CLI. Use `deployment_id` to scope to one deployment and `pod_name` to isolate a single crashing pod.
+
+### Cluster / Kubernetes (READ)
+
+| Tool | Parameters | Use it to | Replaces |
+|---|---|---|---|
+| `get_cluster_status` | `cluster_id`, `category` (`pod`, `networking`, `certificate`, `node`, `storage`, or `custom`), optional `object_filter` | Inspect the health/conditions of Kubernetes objects: pods (CrashLoopBackOff, pending, phase), nodes (pressure, capacity), certificates (TLS provisioning), services/gateways/routes (networking), PVCs (storage) | K8s-level inspection that the REST API doesn't expose |
+| `get_cluster_events` | `cluster_id`, `from_datetime`, `to_datetime`, optional `pod_filter` | Read Kubernetes events (OOMKilled, FailedScheduling, image pull errors, evictions) over a time range. Chunk queries into ≤30-min windows to stay under the 5000-event cap | K8s event inspection the REST API doesn't expose |
+
+`object_filter` accepts a `name` match, a `namespace`, or a Qovery `{environment_id, service_id}` pair — use the service filter to scope directly to the failing service's pods. `pod_filter` on events accepts `service_id` or `pod_name`.
+
+### Config reads, diagnosis & actions — `devops_copilot`
+
+`devops_copilot` is the single tool for everything the read/inventory tools above don't cover: reading detailed config, running the deployment-failure diagnosis, and applying fixes. **Always resolve IDs first with the tools above, and reference every resource by its UUID in the `message` — never by human-readable name.**
+
+Required params: `organization_id` and a natural-language `message`. Optional scoping: `project_id`, `environment_id`, `thread_id` (continue a prior diagnosis), `instructions`.
+
+| Category | What to ask `devops_copilot` | Replaces |
+|---|---|---|
+| **READ** | Environment status; application details, advanced settings, env vars, custom domains, health checks; database details; cluster advanced/security settings | `GET /application/{id}`, `.../environmentVariable`, `.../customDomain`, `.../healthchecks`, `GET /application/{id}/deploymentHistory` |
+| **TROUBLESHOOT** | Diagnose a failing or stuck deployment; identify which services caused a deployment failure | `GET /environment/{envId}/logs` (v2 deployment logs with error tags, stages, hints) |
+| **WRITE** | Deploy / redeploy / stop / restart / delete environment; deploy / redeploy / stop / restart / scale a service; update resources (CPU/memory); update environment variables; update health checks; update advanced settings; add/remove custom domain; cancel a stuck deployment | `PUT /application/{id}`, `POST /application/{id}/restart`, `POST /environment/{envId}/deploy`, `POST /environment/{envId}/cancelDeployment`, `POST /application/{id}/environmentVariable`, `.../secret`, `PUT /deploymentStage/{id}` |
+
+> **Safety still applies to WRITE calls.** The auto-fix vs. ask-first rules in Phase 4 govern *what* you may change — using `devops_copilot` to apply the change does not bypass them. Ask before any code/Dockerfile/secret/schema change.
+
+Example WRITE message (IDs already resolved):
+
+```
+devops_copilot(
+  organization_id = "<org-uuid>",
+  environment_id  = "<env-uuid>",
+  message = "Increase the memory of service <service-uuid> to 1024 MB, then redeploy it."
+)
+```
+
+---
+
+## MCP Server Setup (if not configured)
 
 If the user wants to enable MCP for richer troubleshooting, guide them:
 
@@ -29,4 +89,3 @@ claude mcp add --transport http qovery https://mcp.qovery.com/mcp --header 'Auth
 ```
 
 ---
-

--- a/qovery-troubleshoot/reference/phase1-context-gathering.md
+++ b/qovery-troubleshoot/reference/phase1-context-gathering.md
@@ -4,6 +4,8 @@ Before diagnosing anything, you MUST understand what's deployed and what the use
 
 ### 1.1 Authenticate
 
+**If you are using the Qovery MCP Server, skip this step** — the MCP Server authenticates internally (OAuth or its configured token), so no token needs to flow through the shell. Authentication below is only needed for the CLI/API fallback tiers.
+
 Use the same authentication flow as the deploy skill:
 1. Check if `QOVERY_CLI_ACCESS_TOKEN` or `QOVERY_API_TOKEN` is set
 2. Try `qovery auth token --print` — if the CLI is authenticated, this outputs a valid token (auto-refreshed). Use with `Authorization: Bearer $(qovery auth token --print)`.
@@ -12,24 +14,28 @@ Use the same authentication flow as the deploy skill:
 
 ### 1.2 Get Overview of All Services
 
-Get the status of everything in the user's environment:
+Get the status of everything in the user's environment. If you don't already have the environment ID (e.g. from a Console URL), resolve it first by chaining `list_organizations` → `list_projects` → `list_environments`.
 
-**Via MCP (preferred):**
+**Via MCP tools (preferred):**
 ```
-"Show me the status of all services in the {environment} environment"
-"What services are failing?"
-"Is everything healthy?"
-"Show failing services"
+list_services(environment_id = "{envId}")
+```
+Returns every service (application, container, job, database, helm, terraform) with its current state — this single call replaces the `/environment/{envId}/statuses` API request. To triage, filter the result for services not in a healthy/running state.
+
+For a narrative status ("what's failing and why"), you can also ask the Copilot:
+```
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Show the status of every service in environment {envId} and list which ones are failing.")
 ```
 
-**Via CLI:**
+**Via CLI (fallback):**
 ```bash
 qovery context set    # Set org/project/environment
 qovery service list   # List all services and statuses
 qovery status         # Detailed status
 ```
 
-**Via API:**
+**Via API (fallback):**
 ```bash
 # Get environment statuses (all services at once)
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
@@ -65,14 +71,20 @@ Ask the user or detect from service statuses:
 
 Once you know which service to diagnose:
 
-**Via MCP:**
+**Via MCP tools (preferred):**
 ```
-"Show me the configuration for {service-name}"
-"Show deployment history for {service-name}"
-"What environment variables are set for {service-name}?"
-```
+# Runtime / build logs — works for ANY service type (app, container, job, database, helm):
+get_service_logs(environment_id = "{envId}", service_id = "{serviceId}")
+#   optional: deployment_id = "{deploymentId}"  → scope to one deployment
+#   optional: pod_name      = "{podName}"        → isolate a single crashing pod
 
-**Via CLI:**
+# Config, deployment history, and env vars — via the Copilot (reference resources by UUID):
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Show the configuration, recent deployment history, and environment variables for service {serviceId}.")
+```
+`get_service_logs` replaces every per-type `curl` log endpoint (and covers job/database/helm logs, which have no API endpoint). `devops_copilot` READ replaces the `/application/{id}`, `/deploymentHistory`, and `/environmentVariable` API calls.
+
+**Via CLI (fallback):**
 ```bash
 qovery application env list          # Environment variables
 
@@ -84,7 +96,7 @@ qovery log --job "name"              # Job (cronjob/lifecycle) logs
 qovery log --service "name"          # Generic — works for any service type
 ```
 
-**Via API:**
+**Via API (fallback):**
 ```bash
 # Service details
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
@@ -105,7 +117,7 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
 # Container logs
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
   "https://api.qovery.com/container/{containerId}/log" | jq '.results[-50:] | .[] | .message'
-# NOTE: Job, Helm, and Database log API endpoints do NOT exist — use `qovery log` CLI instead.
+# NOTE: Job, Helm, and Database log API endpoints do NOT exist — use `get_service_logs` (MCP) or `qovery log` CLI instead.
 
 # Environment deployment logs (v2 — includes error details, stages, and hints):
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \

--- a/qovery-troubleshoot/reference/phase2-8-layer-diagnosis.md
+++ b/qovery-troubleshoot/reference/phase2-8-layer-diagnosis.md
@@ -6,14 +6,18 @@ Work through these layers IN ORDER, from most common to least common. Stop at th
 
 **What to check:** Current service state and recent deployment history.
 
-**Via MCP:**
+**Via MCP tools (preferred):**
 ```
-"Why is my deployment failing?"
-"Show deployment history for {service-name}"
-"What happened during the last deployment?"
-```
+# Current state of every service (find the failing one and its state):
+list_services(environment_id = "{envId}")
 
-**Via CLI/API:**
+# Diagnose the failure + read deployment history (rich errors, stages, hints):
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Why is service {serviceId} failing to deploy? Show its recent deployment history and the error details, stages, and hints from the last deployment.")
+```
+The Copilot's TROUBLESHOOT capability replaces the v2 deployment-logs `curl` (`/environment/{envId}/logs`) — it returns the same error tags, stages, and hints. Its READ capability replaces `/deploymentHistory`.
+
+**Via CLI/API (fallback):**
 ```bash
 qovery status
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
@@ -44,14 +48,18 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
 
 **When to check:** Service state is `BUILD_ERROR`.
 
-**Via MCP:**
+**Via MCP tools (preferred):**
 ```
-"Show build logs for {service-name}"
-"Analyze failed build logs"
-"Why is my build failing?"
-```
+# Fetch the failing deployment's logs for any service type:
+get_service_logs(environment_id = "{envId}", service_id = "{serviceId}", deployment_id = "{deploymentId}")
 
-**Via CLI:**
+# Or have the Copilot analyze the build failure directly:
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Analyze the failed build logs for service {serviceId} and tell me which step failed and why.")
+```
+`get_service_logs` works for applications, containers, jobs, and helms — replacing both the per-type `curl` log endpoints and the `qovery log` CLI, including the job/helm cases the API cannot serve.
+
+**Via CLI (fallback):**
 ```bash
 # Use the flag matching the service type (--application, --container, --job, or --service):
 qovery log --application "name" --since 30m
@@ -60,7 +68,7 @@ qovery log --job "name" --since 30m
 qovery log --service "name" --since 30m     # Generic — works for any service type
 ```
 
-**Via API:**
+**Via API (fallback):**
 ```bash
 # Application build logs
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
@@ -68,7 +76,7 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
 # Container build logs
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
   "https://api.qovery.com/container/{containerId}/log" | jq '.results[] | .message'
-# NOTE: For jobs/helms, use `qovery log` CLI — no API log endpoint exists for these service types.
+# NOTE: For jobs/helms, use `get_service_logs` (MCP) or `qovery log` CLI — no API log endpoint exists for these service types.
 ```
 
 **Error patterns and fixes:**
@@ -90,14 +98,23 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
 
 **When to check:** Service was deployed but is crashing, returning errors, or misbehaving.
 
-**Via MCP:**
+**Via MCP tools (preferred):**
 ```
-"Show error logs from the last hour for {service-name}"
-"Why is my app returning 500 errors?"
-"Investigate application crashes for {service-name}"
-```
+# Application/runtime logs for any service type (isolate a crashing pod with pod_name):
+get_service_logs(environment_id = "{envId}", service_id = "{serviceId}")
 
-**Via CLI:**
+# Pod-level health — is it CrashLoopBackOff, Pending, OOMKilled? Scope to the service:
+get_cluster_status(cluster_id = "{clusterId}", category = "pod",
+  object_filter = { type = "service", environment_id = "{envId}", service_id = "{serviceId}" })
+
+# Kubernetes events (OOMKilled, SIGKILL, evictions, image pull errors) over a time window:
+get_cluster_events(cluster_id = "{clusterId}",
+  from_datetime = "{start ISO-8601}", to_datetime = "{end ISO-8601}",
+  pod_filter = { type = "service_id", service_id = "{serviceId}" })
+```
+`get_service_logs` replaces the per-type log `curl` endpoints (and covers job/database/helm). For crash/OOM symptoms, `get_cluster_status` (pod conditions) and `get_cluster_events` (the actual `OOMKilled`/`SIGKILL`/`FailedScheduling` events) give the Kubernetes-level signal the REST API can't. Chunk event queries into ≤30-min windows.
+
+**Via CLI (fallback):**
 ```bash
 # Get recent logs — use the flag matching the service type:
 qovery log --application "name" --since 1h    # Application
@@ -124,7 +141,7 @@ qovery log --service "name" --tail 100
 qovery log --service "name" --from "2024-01-01T00:00:00Z" --to "2024-01-01T23:59:59Z"
 ```
 
-**Via API:**
+**Via API (fallback):**
 ```bash
 # Application logs (last 1000 lines)
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
@@ -135,7 +152,7 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
   "https://api.qovery.com/container/{containerId}/log" | jq '.results[-50:] | .[] | {created_at, message, pod_name}'
 
 # NOTE: Job, Helm, and Database log API endpoints do NOT exist.
-# Use `qovery log --job`, `qovery log --database`, or MCP queries for these service types.
+# Use `get_service_logs` (MCP), or `qovery log --job` / `qovery log --database` for these service types.
 
 # Environment deployment logs v2 (useful for deployment-related runtime errors):
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
@@ -177,7 +194,13 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
 **Diagnosis steps:**
 
 1. **Get current health check config:**
+   ```
+   # Preferred (MCP):
+   devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+     message = "Show the health check configuration (liveness and readiness probes) for service {serviceId}.")
+   ```
    ```bash
+   # Fallback (API):
    curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
      "https://api.qovery.com/application/{appId}" | jq '.healthchecks'
    ```
@@ -206,6 +229,22 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
 
 **Fixes:**
 
+**Via MCP tools (preferred)** — the Copilot's WRITE capability updates health checks and ports directly (reference the service by UUID):
+```
+# Fix port mismatch (auto-fix)
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Set the port of service {serviceId} to internal 3000, external 443, protocol HTTP, publicly accessible.")
+
+# Switch to a TCP probe on port 3000 (auto-fix — when app has no /health endpoint)
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Change the liveness probe of service {serviceId} to a TCP probe on port 3000 with a 30s initial delay.")
+
+# Increase initial delay to 120s (auto-fix — when app is slow to start)
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Set the HTTP liveness probe of service {serviceId} to path /health on port 8080 with initial_delay_seconds = 120.")
+```
+
+**Via API (fallback):**
 ```bash
 # Fix port mismatch (auto-fix)
 curl -s -X PUT "https://api.qovery.com/application/{appId}" \
@@ -252,14 +291,13 @@ curl -s -X PUT "https://api.qovery.com/application/{appId}" \
 
 **When to check:** App starts but crashes due to missing config, or connects to wrong services.
 
-**Via MCP:**
+**Via MCP tools (preferred):**
 ```
-"What environment variables are set for {service-name}?"
-"Why isn't my environment variable working?"
-"Show configuration for {service-name}"
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "List the environment variables and secrets set for service {serviceId}, including their scope and whether each is an alias or interpolated value.")
 ```
 
-**Via CLI:**
+**Via CLI (fallback):**
 ```bash
 qovery application env list
 ```
@@ -292,6 +330,23 @@ qovery application env list
 
 **Fixes:**
 
+**Via MCP tools (preferred)** — the Copilot's WRITE capability manages environment variables:
+```
+# Add a missing non-secret variable (auto-fix)
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Add environment variable PORT=8080 to service {serviceId}.")
+
+# Create an alias for the database connection (auto-fix)
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "On service {serviceId}, create an env var DATABASE_URL as an alias of the variable {sourceVariableId}.")
+
+# For missing secrets — ASK USER for the value first, then:
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Add secret API_KEY to service {serviceId}.", instructions = "The secret value was provided by the user.")
+```
+> Adding/changing secrets requires user approval per Phase 4 — ask before writing.
+
+**Via API (fallback):**
 ```bash
 # Add a missing non-secret variable (auto-fix)
 curl -s -X POST "https://api.qovery.com/application/{appId}/environmentVariable" \
@@ -327,7 +382,12 @@ curl -s -X POST "https://api.qovery.com/application/{appId}/secret" \
 **Diagnosis steps:**
 
 1. **Is the target service running?**
+   ```
+   # Preferred (MCP) — states of every service in the environment:
+   list_services(environment_id = "{envId}")
+   ```
    ```bash
+   # Fallback (CLI):
    qovery service list
    ```
    If the database or dependent service is not running, that's the problem.
@@ -365,6 +425,14 @@ curl -s -X POST "https://api.qovery.com/application/{appId}/secret" \
    ```
 
 **Fixes:**
+
+**Via MCP tools (preferred)** — ask the Copilot to reorder deployment stages so the dependency deploys first:
+```
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "In environment {envId}, order the deployment stages so the database service {dbServiceId} deploys before the application {serviceId}.")
+```
+
+**Via API (fallback):**
 ```bash
 # Fix deployment stage ordering (auto-fix)
 curl -s -X PUT "https://api.qovery.com/deploymentStage/{stageId}" \
@@ -386,12 +454,24 @@ curl -s -X PUT "https://api.qovery.com/deploymentStage/{stageId}" \
 "Optimize resource allocation for {service-name}"
 ```
 
-**Via CLI:**
+**Via MCP tools (preferred):**
+```
+# Current CPU/memory/instance allocation:
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Show the CPU, memory, and min/max instance configuration for service {serviceId}.")
+
+# Confirm OOM from Kubernetes events rather than guessing from allocation:
+get_cluster_events(cluster_id = "{clusterId}",
+  from_datetime = "{start ISO-8601}", to_datetime = "{end ISO-8601}",
+  pod_filter = { type = "service_id", service_id = "{serviceId}" })
+```
+
+**Via CLI (fallback):**
 ```bash
 qovery status    # Shows current resource usage if available
 ```
 
-**Via API:**
+**Via API (fallback):**
 ```bash
 # Get service configuration (cpu, memory, instances)
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
@@ -422,6 +502,23 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
    - For ML/GPU workloads: size based on model requirements
 
 **Fixes:**
+
+**Via MCP tools (preferred)** — the Copilot's WRITE capability updates resources and autoscaling:
+```
+# Increase memory to 1024 MB (auto-fix)
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Set the memory of service {serviceId} to 1024 MB.")
+
+# Increase CPU to 1000 millicores (auto-fix)
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Set the CPU of service {serviceId} to 1000m.")
+
+# Enable autoscaling: min 2, max 10 instances (auto-fix)
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Set service {serviceId} to autoscale between 2 and 10 instances.")
+```
+
+**Via API (fallback):**
 ```bash
 # Increase memory (auto-fix)
 curl -s -X PUT "https://api.qovery.com/application/{appId}" \
@@ -455,12 +552,28 @@ curl -s -X PUT "https://api.qovery.com/application/{appId}" \
 "What version of Kubernetes is running?"
 ```
 
-**Via CLI:**
+**Via MCP tools (preferred):**
+```
+# Node health, pressure, and capacity (also surfaces Karpenter NodePools):
+get_cluster_status(cluster_id = "{clusterId}", category = "node")
+
+# Cluster-wide events over a window (FailedScheduling, node NotReady, evictions).
+# Chunk into ≤30-min windows to stay under the 5000-event cap; omit pod_filter for all events:
+get_cluster_events(cluster_id = "{clusterId}",
+  from_datetime = "{start ISO-8601}", to_datetime = "{end ISO-8601}")
+
+# Cluster-level settings / status narrative:
+devops_copilot(organization_id = "{orgId}",
+  message = "Show the status, advanced settings, and security settings for cluster {clusterId}.")
+```
+`get_cluster_status` and `get_cluster_events` give the Kubernetes-level node and scheduling signal that the `/cluster` REST endpoint doesn't expose.
+
+**Via CLI (fallback):**
 ```bash
 qovery cluster list
 ```
 
-**Via API:**
+**Via API (fallback):**
 ```bash
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
   "https://api.qovery.com/organization/{orgId}/cluster" | jq '.results[] | {id, name, status, cloud_provider, region, version}'

--- a/qovery-troubleshoot/reference/phase3-playbooks.md
+++ b/qovery-troubleshoot/reference/phase3-playbooks.md
@@ -30,7 +30,7 @@ Pre-built diagnostic sequences for the most common problems. Jump directly to th
 
 **Triggers:** "can't connect to database", "ECONNREFUSED", "connection timeout", "database unreachable"
 
-1. Is the database service running? (Layer 1 — `qovery service list`)
+1. Is the database service running? (Layer 1 — `list_services(environment_id="{envId}")`, or `qovery service list`)
 2. Are deployment stages correct? (Layer 6 — DB must deploy before app)
 3. Is `DATABASE_URL` set correctly? (Layer 5 — should be an alias, not hardcoded)
 4. Is it using `_INTERNAL` hostname? (Layer 5 — `_HOST_INTERNAL`, not `_HOST`)
@@ -52,11 +52,15 @@ Pre-built diagnostic sequences for the most common problems. Jump directly to th
 3. Check cluster status (Layer 8) — is the cluster healthy?
 4. Check if there are resource constraints (no node capacity)
 5. Cancel the stuck deployment and retry:
+   ```
+   # Preferred (MCP):
+   devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+     message = "Cancel the ongoing deployment in environment {envId}.")
+   ```
    ```bash
-   # Cancel via API
+   # Fallback (API):
    curl -s -X POST "https://api.qovery.com/environment/{envId}/cancelDeployment" \
      -H "Authorization: Token $QOVERY_API_TOKEN"
-   # Or via MCP: "Cancel the ongoing deployment"
    ```
 6. Retry the deployment
 7. If it's still stuck: check Qovery Console for more details or contact support
@@ -66,7 +70,13 @@ Pre-built diagnostic sequences for the most common problems. Jump directly to th
 **Triggers:** "domain not working", "SSL error", "certificate issue", "custom domain 404"
 
 1. Check if the custom domain is registered in Qovery:
+   ```
+   # Preferred (MCP):
+   devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+     message = "List the custom domains configured for service {serviceId}.")
+   ```
    ```bash
+   # Fallback (API):
    curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
      "https://api.qovery.com/application/{appId}/customDomain" | jq
    ```
@@ -76,7 +86,12 @@ Pre-built diagnostic sequences for the most common problems. Jump directly to th
    # Must point to the Qovery-generated domain
    ```
 3. Check if the service is publicly accessible (port config has `publicly_accessible: true`)
-4. Check TLS certificate — Qovery uses Let's Encrypt, may take a few minutes to provision
+4. Check TLS certificate — Qovery uses Let's Encrypt, may take a few minutes to provision.
+   Inspect the cert-manager objects directly to see whether it's still issuing:
+   ```
+   get_cluster_status(cluster_id = "{clusterId}", category = "certificate",
+     object_filter = { type = "service", environment_id = "{envId}", service_id = "{serviceId}" })
+   ```
 5. Check if the protocol is `HTTP` (not `TCP`/`UDP`) for web traffic
 6. If DNS is correct but still not working: wait 5-10 minutes for DNS propagation
 
@@ -84,7 +99,7 @@ Pre-built diagnostic sequences for the most common problems. Jump directly to th
 
 **Triggers:** "terraform error", "terraform plan failed", "terraform service stuck"
 
-1. Fetch Terraform execution logs via MCP or API
+1. Fetch Terraform execution logs — `get_service_logs(environment_id="{envId}", service_id="{serviceId}")` (MCP, preferred), or `qovery log --service "name"`
 2. Common causes:
    - **Variable errors**: Missing or wrong `variables` in the Terraform service config
    - **Permission errors**: Cloud credentials don't have required IAM permissions
@@ -97,7 +112,7 @@ Pre-built diagnostic sequences for the most common problems. Jump directly to th
 
 **Triggers:** "helm install failed", "chart error", "helm timeout"
 
-1. Fetch Helm install/upgrade logs via MCP or API
+1. Fetch Helm install/upgrade logs — `get_service_logs(environment_id="{envId}", service_id="{serviceId}")` (MCP, preferred), or `qovery log --service "name"`
 2. Common causes:
    - **Invalid values**: YAML syntax error in `values_override`
    - **Missing dependencies**: Chart requires a dependency that isn't deployed
@@ -123,7 +138,14 @@ Pre-built diagnostic sequences for the most common problems. Jump directly to th
 **Manual diagnosis:**
 
 1. **List all services with resource allocations:**
+   ```
+   # Preferred (MCP) — services + states, then per-service config via the Copilot:
+   list_services(environment_id = "{envId}")
+   devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+     message = "Show the CPU, memory, and instance allocation for every service in environment {envId}.")
+   ```
    ```bash
+   # Fallback (API):
    curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
      "https://api.qovery.com/environment/{envId}/statuses" | jq
    ```
@@ -157,7 +179,13 @@ Pre-built diagnostic sequences for the most common problems. Jump directly to th
 
 1. Confirm OOM from logs (Layer 3): `OOMKilled`, `exit code 137`, `SIGKILL`
 2. Check current memory allocation:
+   ```
+   # Preferred (MCP):
+   devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+     message = "What is the current memory allocation for service {serviceId}?")
+   ```
    ```bash
+   # Fallback (API):
    curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
      "https://api.qovery.com/application/{appId}" | jq '.memory'
    ```

--- a/qovery-troubleshoot/reference/phase4-fix-redeploy.md
+++ b/qovery-troubleshoot/reference/phase4-fix-redeploy.md
@@ -27,6 +27,23 @@
 
 ### Redeploy After Fix
 
+**Via MCP tools (preferred)** — the Copilot's WRITE capability deploys/redeploys/restarts (reference resources by UUID):
+```
+# Redeploy a single service
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Redeploy service {serviceId}.")
+
+# Or redeploy the whole environment
+devops_copilot(organization_id = "{orgId}", environment_id = "{envId}",
+  message = "Redeploy environment {envId}.")
+```
+
+**Via CLI (fallback):**
+```bash
+qovery application redeploy --application "name"
+```
+
+**Via API (fallback):**
 ```bash
 # Redeploy a single service
 curl -s -X POST "https://api.qovery.com/application/{appId}/restart" \
@@ -35,13 +52,6 @@ curl -s -X POST "https://api.qovery.com/application/{appId}/restart" \
 # Or redeploy the whole environment
 curl -s -X POST "https://api.qovery.com/environment/{envId}/deploy" \
   -H "Authorization: Token $QOVERY_API_TOKEN"
-
-# Or via CLI
-qovery application redeploy --application "name"
-
-# Or via MCP
-# "Redeploy the backend application"
-# "Restart the API service"
 ```
 
 ### Watch and Verify

--- a/qovery-troubleshoot/reference/phase5-verification.md
+++ b/qovery-troubleshoot/reference/phase5-verification.md
@@ -4,13 +4,21 @@ After the fix is applied and the service is redeployed:
 
 1. **Check service status:**
    ```
-   MCP: "Is {service-name} healthy now?"
-   CLI: qovery status
+   # Preferred (MCP) — confirm the service is back to a running/healthy state:
+   list_services(environment_id = "{envId}")
+   ```
+   ```bash
+   # Fallback (CLI):
+   qovery status
    ```
 
 2. **Check logs for healthy operation:**
+   ```
+   # Preferred (MCP):
+   get_service_logs(environment_id = "{envId}", service_id = "{serviceId}")
+   ```
    ```bash
-   # Use the flag matching the service type, or --service for any type:
+   # Fallback (CLI):
    qovery log --service "name" --tail 20
    qovery log --service "name" --follow      # Stream in real-time to watch for errors
    ```


### PR DESCRIPTION
To avoid duplicate effort, as copilot/MCP is already doing it.

Mainly asked by Tint.