### PR TITLE
feat(qovery-deploy): add Blueprint catalog support

### DIFF
--- a/evals/qovery-deploy.json
+++ b/evals/qovery-deploy.json
@@ -35,5 +35,33 @@
       "Generates a Python FastAPI Dockerfile with uvicorn from the Phase 3 templates",
       "Does not deploy any service before the cluster status is DEPLOYED or READY"
     ]
+  },
+  {
+    "skills": ["qovery-deploy"],
+    "query": "Deploy my app in production and set up a managed Postgres database for it on AWS",
+    "files": [],
+    "expected_behavior": [
+      "During Phase 1 Group 3, identifies the need for a production database",
+      "Enters Phase 3C and reads reference/phase3c-blueprints.md before reaching for a native MANAGED database or hand-rolled Terraform",
+      "Fetches the blueprint catalog via GET /organization/{organizationId}/blueprint/catalog and finds an aws-rds-postgresql entry",
+      "Resolves the major version and latestTag instead of hand-constructing the tag string",
+      "Fetches the manifest (GET .../manifest?environmentId=...) and only asks the user about editable variable fields without defaults, not context variables",
+      "Presents the blueprint (name, tag, provider) in the Phase 3B deployment plan summary under a Blueprints section and waits for explicit confirmation before calling POST /environment/{environmentId}/blueprint",
+      "Marks password-like variables as is_secret: true when creating the blueprint",
+      "Includes the User-Agent header on every blueprint API call",
+      "After creating the app and the blueprint, lists the blueprint service's exposed environment variables and creates an alias (POST /application/{appId}/environmentVariable/alias) wiring the app's DATABASE_URL-equivalent variable to the blueprint's connection output, per reference/phase6-env-vars.md section 6.10 — does not leave the app with a hardcoded or missing connection string"
+    ]
+  },
+  {
+    "skills": ["qovery-deploy"],
+    "query": "Deploy my Node.js app for local dev/testing with a Postgres database — nothing fancy, just get it running",
+    "files": [],
+    "expected_behavior": [
+      "Even though this is a dev/test deployment, still enters Phase 3C and checks the blueprint catalog first (GET /organization/{organizationId}/blueprint/catalog) rather than jumping straight to a native CONTAINER database",
+      "If a container-based blueprint variant exists for the requested database family, offers it as an option, sized appropriately for dev/test (not a large/production instance class)",
+      "If no blueprint matches or the user declines it in favor of simplicity, falls back to the native CONTAINER-mode database (POST /environment/{envId}/database with mode=CONTAINER) from reference/phase4-cli-api.md 4.4",
+      "Regardless of which path was taken (blueprint or native container database), wires the app's DB connection env var to the deployed resource via alias (reference/phase6-env-vars.md 6.4 or 6.10) before considering the task complete",
+      "Does not skip the Phase 3C catalog check purely because the environment is dev/test"
+    ]
   }
 ]

--- a/qovery-deploy/SKILL.md
+++ b/qovery-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qovery-deploy
-description: Deploys any application, database, Helm chart, or Terraform module to Kubernetes via Qovery. Analyzes the user's codebase, creates missing Dockerfiles, provisions databases (container or managed), sets up environment variables, and deploys via Qovery CLI + API or Terraform provider. Supports Node.js, Python, Go, Java, Ruby, PHP, .NET, React, Vite, Next.js and more. Use when the user asks to deploy, ship, set up, or release an application on Qovery or Kubernetes via Qovery.
+description: Deploys any application, database, Helm chart, Terraform module, or managed infrastructure Blueprint (RDS, Redis, S3, and more) to Kubernetes via Qovery. Analyzes the user's codebase, creates missing Dockerfiles, provisions databases (container, managed, or blueprint) and cloud resources, sets up environment variables, and deploys via Qovery CLI + API or Terraform provider. Supports Node.js, Python, Go, Java, Ruby, PHP, .NET, React, Vite, Next.js and more. Use when the user asks to deploy, ship, set up, or release an application on Qovery or Kubernetes via Qovery.
 license: MIT
 compatibility: opencode
 metadata:
@@ -53,6 +53,7 @@ Deployment Progress:
 - [ ] Phase 2 — Prerequisites & authentication
 - [ ] Phase 2B — Cluster setup (only if no cluster exists)
 - [ ] Phase 3 — Codebase analysis & Dockerfile creation
+- [ ] Phase 3C — Blueprint catalog check (MANDATORY whenever any infra piece — DB, cache, storage, queue, etc. — is needed, any environment)
 - [ ] Phase 3B — Deployment plan summary + USER CONFIRMATION
 - [ ] Phase 4 OR Phase 5 — Deploy (CLI+API vs Terraform)
 - [ ] Phase 6 — Environment variables (scopes, aliases, interpolation)
@@ -76,6 +77,7 @@ When entering each phase, read the matching reference file via the bash Read too
 | Phase 2 | [reference/phase2-prereq-auth.md](reference/phase2-prereq-auth.md) | CLI install, login, context, API token |
 | Phase 2B | [reference/phase2b-cluster-setup.md](reference/phase2b-cluster-setup.md) | First-time cluster on AWS / GCP / Azure / Scaleway |
 | Phase 3 | [reference/phase3-dockerfiles.md](reference/phase3-dockerfiles.md) | Production Dockerfile templates for 12+ stacks |
+| Phase 3C | [reference/phase3c-blueprints.md](reference/phase3c-blueprints.md) | Blueprint catalog: reuse managed infra components (RDS, Redis, etc.) instead of hand-rolled Terraform |
 | Phase 3B | [reference/phase3b-deployment-plan.md](reference/phase3b-deployment-plan.md) | Plan summary template + confirmation gate |
 | Phase 4 | [reference/phase4-cli-api.md](reference/phase4-cli-api.md) | Deploy via CLI + API (quick path) |
 | Phase 5 | [reference/phase5-terraform.md](reference/phase5-terraform.md) | Deploy via Terraform provider (production path) |
@@ -93,10 +95,26 @@ Gather four groups of information conversationally (do not dump as a wall of tex
 
 1. **Account & infrastructure** — Qovery org (auto-list via API), cluster (must be `DEPLOYED`/`READY`), project, environment.
 2. **Project analysis** — language, framework, port, public accessibility, monorepo paths.
-3. **Database & services** — type, mode (`CONTAINER` for dev, `MANAGED` for prod), extra cloud resources.
+3. **Database & services** — type, mode (`CONTAINER` for dev, `MANAGED` for prod, or Blueprint if the catalog has a match), extra cloud resources.
 4. **Deployment method** — CLI + API (quick) or Terraform (production).
 
 Detailed questions and API calls live in [reference/phase1-discovery.md](reference/phase1-discovery.md). If the user shared a Qovery Console URL, extract the IDs first using [reference/console-url-detection.md](reference/console-url-detection.md) and skip the corresponding questions.
+
+---
+
+## Phase 3C — Blueprint catalog check
+
+**MANDATORY: whenever any infrastructure piece is needed — a database (dev/test or production), cache, queue, storage bucket, or any other cloud resource — check the Blueprint catalog FIRST**, before deciding between a native `qovery_database` resource (CONTAINER or MANAGED) or a hand-rolled Terraform service. This applies in every environment, not just production. Blueprints are pre-built infrastructure components (managed RDS PostgreSQL/MySQL, Redis, S3, and more) published in the `Qovery/service-catalog` repo, and the catalog can contain both cloud-managed and container-based blueprints for the same service family — check `majorVersions`/manifest rather than assuming a family is only offered one way.
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  "https://api.qovery.com/organization/{organizationId}/blueprint/catalog" | jq '.blueprints[] | {name, provider, serviceFamily}'
+```
+
+Full flow (version/tag resolution, manifest-driven variable prompts, creation, engine overrides, updates) lives in [reference/phase3c-blueprints.md](reference/phase3c-blueprints.md). Skip *deploying* the blueprint only if no matching one exists or the user explicitly wants a bare native resource / fully custom Terraform — but always run the catalog check itself first.
+
+**Whichever infra piece you end up deploying — blueprint, native container database, native managed database, or Terraform service — Phase 6 (env vars) MUST wire dependent applications to it via alias, not hardcoded hostnames.** See the Phase 6 note below.
 
 ---
 
@@ -142,11 +160,16 @@ User wants to deploy with Qovery
 ├─ Needs Database? ─────── NO ──> Skip database setup
 │       │
 │       YES
-│       ├─ Dev/Test? ──────────> Database mode = CONTAINER (cheap, on-cluster)
-│       └─ Production? ───────┬> Database mode = MANAGED (simple, cloud-managed RDS)
-│                              └> Terraform service for RDS Aurora (advanced, full control)
+│       ├─ Phase 3C: check Blueprint catalog FIRST (always — dev/test or production)
+│       │       ├─ Match found ──> deploy the blueprint (may itself be container-based — pick sizing to fit dev/test vs prod)
+│       │       └─ No match ──┬─ Dev/Test? ──> Database mode = CONTAINER (native Qovery resource, cheap, on-cluster)
+│       │                      └─ Production? ─┬> Database mode = MANAGED (simple, cloud-managed RDS)
+│       │                                       └> Terraform service for RDS Aurora (advanced, full control)
+│       └─ Wire dependent apps' env vars to whichever was deployed (alias — Phase 6.10). Never leave a DB unconnected.
 │
-├─ Needs cloud resources? ──> Terraform service (S3, Lambda, CloudFront, etc.)
+├─ Needs cloud resources? ──> Phase 3C: check Blueprint catalog FIRST (always)
+│       ├─ Match found ──> deploy the blueprint (e.g. S3, Redis) — then alias its vars into dependent apps (Phase 6.10)
+│       └─ No match ──> Terraform service (S3, Lambda, CloudFront, etc.)
 │
 ├─ Has Helm charts? ────────> qovery_helm resource
 │

--- a/qovery-deploy/reference/phase1-discovery.md
+++ b/qovery-deploy/reference/phase1-discovery.md
@@ -64,6 +64,8 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
 
 IMPORTANT: Do NOT skip the cluster check. Without a running cluster, no services can be deployed. Store the selected cluster ID — it will be used when creating environments.
 
+**NEVER guess a cluster by pattern-matching its name against the user's username, org name, or project name** (e.g. picking `local-demo-acarrano` because the user is Alessandro Carrano). A name match is not consent. With more than one cluster, always show the full list and ask — no exceptions, even if one name looks like an obvious personal/demo cluster. This matters even more when the deployment involves cloud resources (a database, a Blueprint, a Terraform service) whose provider/region must match the chosen cluster — silently picking the wrong cluster here means provisioning real infrastructure in the wrong place, cloud account, or region.
+
 #### Step 4: Resolve Project & Environment
 
 Ask the user:
@@ -105,11 +107,14 @@ Then tell the user what you detected and ask:
    - Look for database connection strings in code, ORM configs (Prisma, TypeORM, SQLAlchemy, GORM, etc.)
 
 9. **Is this deployment for development/testing or production?**
-   - **Dev/test** -> Database in Container mode (cheaper, runs on the Kubernetes cluster, fast to provision)
-   - **Production** -> Database in Managed mode (cloud-managed, e.g. AWS RDS — higher availability, automated backups) OR via a Terraform service for advanced setups like RDS Aurora Serverless
+   - Regardless of the answer, check the **Blueprint catalog first** (Phase 3C) before reaching for a native database resource or a hand-rolled Terraform service — the catalog can offer both cloud-managed and container-based variants, so it's worth checking even for dev/test.
+   - **Dev/test, no blueprint match** -> Use Qovery's native database service in Container mode (cheaper, runs on the Kubernetes cluster, fast to provision, disposable).
+   - **Production, no blueprint match** -> Managed-mode database (e.g. AWS RDS) or a hand-rolled Terraform service for setups the catalog doesn't cover (e.g. a custom Aurora Serverless topology).
 
 10. **Do you need any additional cloud resources?** (S3 buckets, Redis cache, message queues, Lambda functions, CDN, etc.)
-    - These can be provisioned via Qovery Terraform services
+    - Check the **Blueprint catalog** (Phase 3C) first, in any environment. Anything not covered by a blueprint can still be provisioned via a hand-rolled Qovery Terraform service.
+
+11. Whatever gets deployed above (blueprint, native container/managed database, or Terraform service), the application(s) depending on it MUST have their environment variables wired to it via **alias** before the deployment is considered complete (Phase 6.10). Never leave an application pointing at a hardcoded or missing connection string for a piece of infrastructure that was just provisioned.
 
 ### Group 4: Deployment Method
 

--- a/qovery-deploy/reference/phase3b-deployment-plan.md
+++ b/qovery-deploy/reference/phase3b-deployment-plan.md
@@ -30,6 +30,12 @@ Based on all information gathered in Phase 1 (user answers, resolved organizatio
 > | postgres | PostgreSQL | 16 | Container | 10GB | — |
 > | redis | Redis | 7 | Container | 5GB | — |
 >
+> **Blueprints to deploy** *(reused from the catalog instead of hand-rolled Terraform — see Phase 3C)*:
+>
+> | Name | Blueprint tag | Provider | Category |
+> |------|---------------|----------|----------|
+> | prod-postgres | aws/postgres/17/1.0.1 | AWS | Managed Database |
+>
 > **Deployment stages (execution order):**
 > 1. **Infrastructure**: postgres, redis
 > 2. **Backend**: backend, worker
@@ -39,6 +45,7 @@ Based on all information gathered in Phase 1 (user answers, resolved organizatio
 > - `PORT` = `8080`
 > - `NODE_ENV` = `production`
 > - `DATABASE_URL` = alias -> `QOVERY_DATABASE_..._CONNECTION_URI_INTERNAL`
+> - `PROD_DATABASE_URL` (backend) = alias -> `prod-postgres` blueprint's `endpoint` output *(see Phase 3C/6.10 — every app depending on a blueprint MUST have its connection wired via alias here)*
 > - `JWT_SECRET` = *(secret — value provided by user)*
 > - *(N other variables from .env file)*
 >
@@ -53,7 +60,7 @@ Based on all information gathered in Phase 1 (user answers, resolved organizatio
 > - Database `postgres` is in **Container** mode — suitable for dev/test but not recommended for production workloads
 > - Frontend has no `.dockerignore` — `node_modules` will be excluded via the generated file
 
-Adapt this template to the actual services detected. Omit sections that don't apply (e.g., no "Databases" section if no databases are needed, no "Files to create" if all Dockerfiles exist).
+Adapt this template to the actual services detected. Omit sections that don't apply (e.g., no "Databases" section if no databases are needed, no "Blueprints" section if the catalog had no match for anything requested, no "Files to create" if all Dockerfiles exist).
 
 For the **Terraform path**, also include:
 > **Terraform files to generate:**
@@ -78,7 +85,7 @@ If the user wants to modify the plan:
 
 Common change requests:
 - Switch cluster (e.g., "use staging instead of production")
-- Change database mode (e.g., "use managed for production")
+- Change database mode (e.g., "use managed for production", "use the RDS blueprint instead of a container database")
 - Adjust resources (e.g., "give the backend 1GB memory")
 - Change port or public accessibility
 - Add/remove services

--- a/qovery-deploy/reference/phase3c-blueprints.md
+++ b/qovery-deploy/reference/phase3c-blueprints.md
@@ -1,0 +1,161 @@
+## PHASE 3C: Blueprint Catalog Check
+
+A **Blueprint** is a pre-built infrastructure component — a managed RDS PostgreSQL/MySQL instance, a Redis deployment, an S3 bucket, and similar pieces — published in the public `Qovery/service-catalog` GitHub repository. Deploying a blueprint reuses a maintained Terraform/OpenTofu module or Helm chart instead of hand-writing one from scratch. A single `serviceFamily` in the catalog can ship both cloud-managed and container-based variants (check the specific blueprint's `majorVersions`/manifest rather than assuming a family is only offered one way) — blueprints are not exclusively "the cloud-managed option."
+
+This is distinct from Qovery's built-in **native container database** service (`qovery_database` resource in CONTAINER mode, Phase 4.4 / 5.6) — that is a first-class Qovery resource, not something sourced from the catalog.
+
+**MANDATORY rule: whenever any infrastructure piece is needed — a database (dev/test or production), cache, queue, storage bucket, or any other cloud resource — check the blueprint catalog FIRST, before deciding between a native `qovery_database` resource (CONTAINER or MANAGED mode) or a hand-rolled Terraform service.** This applies regardless of environment (dev/test/staging/production). Never skip straight to Phase 4/5 for an infrastructure piece without checking 3C.1 first.
+
+- **Blueprint match found** -> deploy the blueprint (3C.2 onward). A matching blueprint can itself be container-based, so this doesn't force cloud/managed infra onto a dev/test environment — check the specific blueprint's shape via its manifest (3C.3) and pick the option (or variable overrides) that fits dev/test vs. production sizing.
+- **No blueprint match** -> fall back to the native resource: CONTAINER mode for dev/test, MANAGED mode or a hand-rolled Terraform service for production (Phase 4/5).
+- **User explicitly asks to skip the catalog** (e.g. wants full control over Terraform code, or just says "use a container database") -> honor that and go straight to Phase 4/5, but only when it's an explicit ask, not a default.
+
+### 3C.1 Fetch the Catalog
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  "https://api.qovery.com/organization/{organizationId}/blueprint/catalog" \
+  | jq '.blueprints[] | {name, provider, serviceFamily, categories, majorVersions: [.majorVersions[].serviceVersion]}'
+```
+
+Cache this list for the conversation — do not re-fetch it per service. Match the user's need (e.g. "I need Postgres in prod", "add a Redis cache") against `serviceFamily` + `provider` + `categories`. If the target cloud provider isn't obvious, use the same provider as the user's cluster (resolved in Phase 1) — but this only works if the cluster itself was properly resolved and confirmed with the user in Phase 1, not guessed. If a cloud resource (S3 bucket, managed database, etc.) is needed and the cluster hasn't been explicitly confirmed yet (e.g. more than one cluster exists and the user hasn't picked one), stop and go back to Phase 1 Step 3 to ask — do not infer the cluster from a name pattern just to unblock the blueprint provider match.
+
+- **Match found** -> continue with 3C.2.
+- **No match** -> tell the user no blueprint exists for this component yet, and fall back to Phase 4 (native database) or Phase 5/8 (hand-written Terraform service).
+
+### 3C.2 Pick a Version and Resolve the Tag
+
+Each `BlueprintItem` has one or more `majorVersions`, each with a `serviceVersion` (e.g. `"17"`) and a `latestTag` (e.g. `aws/postgres/17/1.0.1`). Ask the user which major version they want if more than one is available, otherwise use the only one. The `latestTag` is what you pass as `tag` when creating the service — do not hand-construct this string.
+
+Optionally show the blueprint's README before proceeding, especially if the user wants to understand what the module provisions:
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  "https://api.qovery.com/organization/{organizationId}/blueprint/catalog/{provider}/{serviceFamily}/{serviceVersion}/readme" \
+  | jq -r '.content'
+```
+
+### 3C.3 Fetch the Manifest (Form Fields)
+
+Before creating the blueprint, fetch its manifest to learn which variables are required, which are optional, and what the engine defaults are. `environmentId` is required — use the environment resolved/created in Phase 1.
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  "https://api.qovery.com/organization/{organizationId}/blueprint/catalog/{provider}/{serviceFamily}/{serviceVersion}/manifest?environmentId={environmentId}" \
+  | jq '.'
+```
+
+The response's `results` array mixes two field kinds:
+- `kind: "variable"` — user-editable input (e.g. `db_password`, instance size). Respect `required`, `is_secret`, `allowed_values`, `default_value`, and the type constraints in `type` (pattern/min_length/max_length for strings, min/max for numbers). Only ask the user about fields with no `default_value`, or where they may want to override the default.
+- `kind: "contextVariable"` — read-only, auto-sourced from the cluster/environment (e.g. `region`). Never ask the user for these or pass them in `variables` — they resolve automatically.
+
+The manifest also returns `engine` — the discriminated `terraform` / `opentofu` / `helm` spec with catalog defaults for version, credentials, backend, timeout, and resources. Use these defaults unless the user asks to override (see 3C.5).
+
+### 3C.4 Create the Blueprint
+
+```bash
+curl -s -X POST "https://api.qovery.com/environment/{environmentId}/blueprint?deploy=false" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  -d '{
+    "name": "my-postgres",
+    "tag": "aws/postgres/17/1.0.1",
+    "icon": "https://cdn.qovery.com/icons/postgresql.svg",
+    "variables": [
+      { "name": "instance_class", "value": "db.t3.medium", "is_secret": false },
+      { "name": "db_password", "value": "REPLACE_ME", "is_secret": true }
+    ]
+  }' | jq '{id, tag, environment_id, catalog_url}'
+```
+
+- `name`, `tag`, and `icon` are required. Use the `icon` URL and `latestTag` from the catalog entry (3C.1) — do not invent one.
+- `variables` only needs entries for fields you're overriding or that have no default; omit anything you're leaving at its manifest default.
+- Set `is_secret: true` for any variable the manifest marked `is_secret: true` (passwords, API keys, connection secrets) — these are encrypted at rest and excluded from plan/diff output.
+- Set the query param `deploy=true` instead of `false` to trigger deployment immediately on creation — but per this skill's Phase 3B rule, only do this after the user has confirmed the deployment plan. Prefer `deploy=false` here and trigger deployment explicitly in Phase 4/9 alongside the rest of the environment.
+- `409` means a service with this name already exists in the environment — ask the user for a different name or reuse the existing service.
+- `422` means the `tag` is malformed — re-fetch the catalog (3C.1) and use the exact `latestTag` string.
+
+### 3C.5 Engine Overrides (Advanced)
+
+Pass `spec_overrides` only when the user wants non-default engine behavior. Only fields the manifest marked `overridable: true` are accepted — anything else returns `422`.
+
+```json
+{
+  "name": "my-postgres",
+  "tag": "aws/postgres/17/1.0.1",
+  "icon": "https://cdn.qovery.com/icons/postgresql.svg",
+  "variables": [],
+  "spec_overrides": {
+    "engine_version": "1.13.3",
+    "credentials": "cluster",
+    "backend": "qovery",
+    "cpu": "500m",
+    "ram": "512Mi"
+  }
+}
+```
+
+- **Terraform/OpenTofu blueprints**: `engine_version` is REQUIRED on create — pick one of `spec.engine.terraform.allowedValues` (or `opentofu.allowedValues`) from the manifest. `credentials: cluster` (default, reuses cluster cloud credentials) vs `env` (user supplies provider credentials as env vars on the service). `backend: qovery` (default, state in a Kubernetes secret) vs `user_provided` (state in a user-controlled remote backend declared in the manifest).
+- **Helm blueprints**: `engine_version`, `credentials`, and `backend` are ignored — only `timeout` and the resource fields (`cpu`, `ram`, `storage`) apply.
+
+### 3C.6 Wiring the Blueprint into the Rest of the Environment (MANDATORY)
+
+A blueprint that's created and deployed but never connected to the application(s) that need it is an incomplete deployment. Every application depending on a blueprint MUST have its environment variables wired to it before the task is considered done:
+
+- List the blueprint's exposed variables and **alias** them into the dependent application(s) — never hardcode the blueprint's host/port/password/endpoint. Full step-by-step in [phase6-env-vars.md](phase6-env-vars.md) section 6.10.
+- Place blueprint services in the **Infrastructure** deployment stage, same as native databases and Terraform services (see [phase5-terraform.md](phase5-terraform.md) 5.5), so they deploy before applications that depend on them. Blueprints created via API are not currently stage-assignable through this endpoint — if strict ordering is required, deploy the blueprint first and confirm it's healthy before deploying dependent applications (Phase 9).
+- This wiring must show up explicitly in the Phase 3B deployment plan (as a "Blueprints to deploy" row plus an "Environment variables to set" alias entry) before the user confirms.
+
+### 3C.7 Checking for and Applying Updates
+
+If the user already has a blueprint-based service and wants to check for a newer catalog version:
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  "https://api.qovery.com/blueprint/{blueprintId}/update" | jq '.'
+```
+
+This returns `is_up_to_date`, `current_tag`, `latest_tag`, and diffs (`new_required_values`, `new_optional_values`, `now_required_values`, `updated_values`, `removed_values`, `engine_diff`, `new_major_versions`). Always show this diff to the user before updating — new required values or breaking `engine_diff` changes need explicit review.
+
+Preview the update as a dry run first (no persisted changes):
+
+```bash
+curl -s -X POST "https://api.qovery.com/blueprint/{blueprintId}/update/preview" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  -d '{"variables": {"instance_class": {"value": "db.t3.large"}}, "spec_overrides": null}'
+```
+
+`variables` and `spec_overrides` follow JSON Merge Patch (RFC 7396) semantics: a non-null value upserts that key, `null` removes it, an absent key is left untouched. Once the user confirms the preview, persist it — `name`, `tag`, and `icon` are required on every call even though only the diffed fields actually change:
+
+```bash
+curl -s -X PATCH "https://api.qovery.com/blueprint/{blueprintId}" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  -d '{
+    "name": "my-postgres",
+    "tag": "aws/postgres/17/1.1.0",
+    "icon": "https://cdn.qovery.com/icons/postgresql.svg",
+    "variables": {"instance_class": {"value": "db.t3.large"}},
+    "spec_overrides": null
+  }' | jq '{id, tag}'
+```
+
+### 3C.8 When NOT to Use a Blueprint
+
+The catalog check (3C.1) always runs first, but the blueprint itself is skipped when:
+
+- **No blueprint exists** yet for the requested component/provider/version combination — fall back to the native database resource (Phase 4.4/5.6/5.7) or a hand-rolled Terraform service (Phase 5.8/5.15) or Helm chart (Phase 5.12).
+- **The user explicitly asks for the native/bare resource** — e.g. "just use a container database", "I don't need a managed anything, keep it simple", or wants full control over hand-written Terraform code rather than a catalog-maintained module.
+- **The user needs Terraform-file-based, version-controlled infrastructure as code committed to their own repo** — blueprints are created and managed through the API/Console, not through the user's `qovery.tf`. Mention this trade-off if they're on the Terraform deployment path (Phase 5).
+
+Never skip the catalog check itself just because the environment is dev/test — a container-based blueprint may still be the best fit; only skip the *blueprint* (not the check) when one of the above applies.
+
+---

--- a/qovery-deploy/reference/phase3c-blueprints.md
+++ b/qovery-deploy/reference/phase3c-blueprints.md
@@ -28,7 +28,7 @@ Cache this list for the conversation — do not re-fetch it per service. Match t
 
 Each `BlueprintItem` has one or more `majorVersions`, each with a `serviceVersion` (e.g. `"17"`) and a `latestTag` (e.g. `aws/postgres/17/1.0.1`). Ask the user which major version they want if more than one is available, otherwise use the only one. The `latestTag` is what you pass as `tag` when creating the service — do not hand-construct this string.
 
-Optionally show the blueprint's README before proceeding, especially if the user wants to understand what the module provisions:
+Fetch and read the blueprint's README before proceeding — it's the module's own documentation and often explains things the manifest's per-field metadata doesn't (e.g. required cloud IAM permissions, conditional requirements between variables, naming/format quirks and why they exist, what shape the outputs take, or lifecycle/update caveats). Use it to inform the questions you ask the user and the plan you present, not just to answer "what does this provision" if asked:
 
 ```bash
 curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
@@ -36,6 +36,8 @@ curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
   "https://api.qovery.com/organization/{organizationId}/blueprint/catalog/{provider}/{serviceFamily}/{serviceVersion}/readme" \
   | jq -r '.content'
 ```
+
+If the README is missing or the request fails (`502`), don't block the flow — proceed with the manifest alone.
 
 ### 3C.3 Fetch the Manifest (Form Fields)
 

--- a/qovery-deploy/reference/phase4-cli-api.md
+++ b/qovery-deploy/reference/phase4-cli-api.md
@@ -63,6 +63,8 @@ curl -s -X POST "https://api.qovery.com/project/{projectId}/environment" \
 
 ### 4.4 Create Database (if needed)
 
+Before creating a native database here, Phase 3C should already have checked the Blueprint catalog for a matching offering (in any environment, not just production) and either deployed a blueprint or confirmed no match exists. Only use the native resource below when Phase 3C found no matching blueprint, or the user explicitly asked for the native/bare resource.
+
 #### Container Mode (dev/test — cheaper, on-cluster)
 
 ```bash
@@ -110,6 +112,8 @@ git remote get-url origin
 - `gitlab.com` or self-hosted GitLab -> `GITLAB`
 - `bitbucket.org` -> `BITBUCKET`
 
+IMPORTANT: The `git_repository.url` MUST end in `.git` (e.g. `https://github.com/user/repo.git`, not `https://github.com/user/repo`). If the URL was obtained from `git remote get-url origin`, it usually already has the suffix. If it was constructed from a `gh repo create` output, a Console-pasted link, or any other source that omits it, append `.git` before using it here.
+
 ```bash
 curl -s -X POST "https://api.qovery.com/environment/{envId}/application" \
   -H "Authorization: Token $QOVERY_API_TOKEN" \
@@ -117,7 +121,7 @@ curl -s -X POST "https://api.qovery.com/environment/{envId}/application" \
   -d '{
     "name": "my-app",
     "git_repository": {
-      "url": "https://github.com/user/repo",
+      "url": "https://github.com/user/repo.git",
       "branch": "main",
       "root_path": "/",
       "provider": "GITHUB"
@@ -215,6 +219,8 @@ curl -s -X POST "https://api.qovery.com/environment/{envId}/container" \
 ### 4.7 Set Environment Variables
 
 IMPORTANT: Use the right scope and mechanism to avoid duplication. See Phase 6 for the full guide on aliases, interpolation, and overrides.
+
+**If any Blueprint was deployed in Phase 3C, this step is mandatory, not optional**: every application that depends on it must have its connection variables aliased to the blueprint's exposed outputs (see [phase6-env-vars.md](phase6-env-vars.md) 6.10) before moving on to Phase 9. A blueprint with no application wired to it is an incomplete deployment.
 
 **Set variables at the appropriate scope:**
 

--- a/qovery-deploy/reference/phase5-terraform.md
+++ b/qovery-deploy/reference/phase5-terraform.md
@@ -62,7 +62,7 @@ variable "environment_mode" {
 }
 
 variable "git_repository_url" {
-  description = "Git repository URL"
+  description = "Git repository URL — MUST end in .git (e.g. https://github.com/user/repo.git)"
   type        = string
 }
 
@@ -185,6 +185,8 @@ resource "qovery_database" "postgres" {
 ```
 
 ### 5.8 Database — RDS Aurora via Terraform Service (Advanced Production)
+
+Before hand-writing this, check the Blueprint catalog ([reference/phase3c-blueprints.md](phase3c-blueprints.md), Phase 3C) — a maintained `aws-rds-postgresql`/`aws-rds-mysql` blueprint may already cover this without owning custom Terraform code. Use the pattern below only for setups the catalog doesn't offer (e.g. a non-standard Aurora Serverless topology, custom VPC peering) or when the user wants full control over the module source.
 
 For advanced database needs (Aurora Serverless, custom VPC configuration, etc.), use a Qovery Terraform service that runs your own Terraform module:
 
@@ -628,6 +630,8 @@ resource "qovery_job" "daily_cleanup" {
 
 ### 5.15 Terraform Service (S3, Lambda, CloudFront, etc.)
 
+Before hand-writing this, check the Blueprint catalog ([reference/phase3c-blueprints.md](phase3c-blueprints.md), Phase 3C) for a maintained module covering the same resource. Use a hand-rolled Terraform service only when no blueprint matches.
+
 For any cloud resource not natively managed by Qovery, use a Terraform service. This runs your own Terraform code as a Qovery-managed job:
 
 ```hcl
@@ -723,7 +727,7 @@ qovery_project_id      = "your-project-uuid"
 qovery_cluster_id      = "your-cluster-uuid"
 environment_name       = "production"
 environment_mode       = "PRODUCTION"
-git_repository_url     = "https://github.com/user/repo"
+git_repository_url     = "https://github.com/user/repo.git"
 git_branch             = "main"
 auto_deploy_enabled    = true
 ```

--- a/qovery-deploy/reference/phase6-env-vars.md
+++ b/qovery-deploy/reference/phase6-env-vars.md
@@ -348,5 +348,32 @@ Follow these rules to keep environment variables clean and DRY:
 
 8. **Secrets are scoped too**: Secret overrides work the same way as regular variable overrides. Define a secret at project scope and override its value at environment scope for different environments.
 
+### 6.10 Wiring Applications to a Blueprint-Provisioned Resource (MANDATORY)
+
+Whenever an infrastructure piece was deployed as a **Blueprint** (Phase 3C) instead of a native database, any application that needs to reach it MUST be wired up here — creating the blueprint alone does NOT connect it to your app. Do not leave a blueprint deployed with no application referencing it, and never hardcode its connection details.
+
+1. **List the blueprint service's exposed variables** once it's created (and ideally after its first successful deploy, since some values like a generated password or endpoint resolve only post-apply):
+   ```bash
+   curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+     -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+     "https://api.qovery.com/environment/{environmentId}/environmentVariable" \
+     | jq '.results[] | select(.service_id == "{blueprintServiceId}") | {id, key, scope}'
+   ```
+   Terraform/OpenTofu-engine blueprints expose their module's `output` blocks as environment variables on the service (e.g. a generated `endpoint`, `port`, `username`, `password`); Helm-engine blueprints expose whatever the chart's notes/values surface the same way native Helm services do. Names vary by blueprint — there's no fixed `QOVERY_DATABASE_*` pattern like native databases have, so always list them rather than guessing.
+
+2. **Alias each variable the application needs**, exactly like you would for a native database (6.4) — never hardcode the blueprint's host/port/password into the application's own variables:
+   ```bash
+   curl -s -X POST "https://api.qovery.com/application/{appId}/environmentVariable/alias" \
+     -H "Authorization: Token $QOVERY_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     -H "User-Agent: QoverySkill/qovery-deploy (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+     -d '{"key": "DATABASE_URL", "alias_parent_id": "{blueprintEndpointVariableId}"}'
+   ```
+   If the blueprint doesn't expose one composed connection-string variable (common for Terraform-engine blueprints, which tend to expose host/port/user/password separately), alias each part individually and compose the final URL with **interpolation** (6.5) the same way you would compose a custom-params `DATABASE_URL` from a native database's parts.
+
+3. **Confirm in the Phase 3B plan**: the "Environment variables to set" section must list the alias/interpolation wiring from each application to each blueprint it depends on — this is exactly as required as wiring to a native database, and must be present before the user confirms the plan.
+
+4. **Verify after deploy** (Phase 9): once both the blueprint and the dependent application are healthy, confirm the application can actually resolve and use the aliased variables (e.g. check logs for a successful DB connection, or exec into the pod and inspect the env). A blueprint that deployed successfully but whose variables were never wired into the consuming service is an incomplete deployment — treat it as a failure to fix (Phase 10), not a done task.
+
 ---
 

--- a/qovery-deploy/reference/phase8-advanced-patterns.md
+++ b/qovery-deploy/reference/phase8-advanced-patterns.md
@@ -71,6 +71,8 @@ git remote get-url origin
 
 IMPORTANT: The user's Qovery organization must have the corresponding git provider connected (GitHub App installed, GitLab token, or Bitbucket integration). Check this at Organization Settings > Git Repository Access in the Qovery Console.
 
+IMPORTANT: Whatever URL ends up in `git_repository.url` (API) or `git_repository_url` (Terraform) MUST end in `.git`. `git remote get-url origin` usually already includes it, but a URL freshly created via `gh repo create`, copied from a browser address bar, or typed by the user often won't — append `.git` before using it in any create-application/create-terraform-service call.
+
 ### 8.6 Monorepo Support
 
 For monorepos with multiple services in subdirectories:


### PR DESCRIPTION
## Summary

- Adds a new **Phase 3C** to `qovery-deploy`: before provisioning any infrastructure piece (database, cache, storage bucket, etc.), in any environment, the skill must check the Qovery Blueprint catalog (`GET /organization/{organizationId}/blueprint/catalog`) instead of defaulting straight to a hand-rolled Terraform service or native database resource. Covers catalog lookup, version/tag resolution, manifest-driven variable prompts, blueprint creation, engine overrides (Terraform/OpenTofu/Helm), and update flow (`reference/phase3c-blueprints.md`, new file).
- Requires that whichever infra piece ends up deployed (blueprint or native), dependent applications' env vars are wired to it via **alias**, never hardcoded — added `phase6-env-vars.md` §6.10 and cross-referenced it from Phase 3C, Phase 4, and the Phase 3B plan template.
- Fixes two gaps surfaced during manual end-to-end testing:
  - **Cluster selection must never be guessed from a name pattern** (e.g. picking a cluster because its name matches the user's username). Tightened `phase1-discovery.md` Step 3 and `phase3c-blueprints.md` to require asking explicitly whenever more than one cluster exists, especially before a cloud-resource/blueprint decision that depends on the cluster's provider.
  - **Git repository URLs must always carry the `.git` suffix.** URLs from `gh repo create` output or console-pasted links often omit it; fixed examples and added the rule in `phase4-cli-api.md`, `phase5-terraform.md`, and `phase8-advanced-patterns.md`.
- Added an eval scenario in `evals/qovery-deploy.json` exercising the blueprint flow end-to-end.

## Test plan

- [x] `for f in qovery-*/SKILL.md; do wc -l "$f"; done` — all under 500 lines
- [x] All internal `reference/`/`templates/`/`examples/` links in `SKILL.md` resolve
- [x] No leaked anti-patterns (2nd-person openers, `as of <year>`, AI co-author trailers)
- [x] `evals/qovery-deploy.json` is valid JSON
- [x] Manually tested via `local-install.sh --global` symlink install against a real Qovery org/project, which is what surfaced the cluster-guessing and `.git`-suffix issues fixed here