### PR TITLE
feat: add qovery-cluster-ops skill (node churn, Karpenter, upgrades)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ AI agent skills for deploying and troubleshooting applications on Kubernetes usi
 | **qovery-speedup** | Speed up deployments — measures pipeline timeline, identifies bottlenecks (build, startup, health check, scheduling), classifies user vs Qovery responsibility, proposes Dockerfile and config fixes |
 | **qovery-preview** | Create preview environments from PRs — detects/creates blueprint environments, clones for each PR, switches branches, configures auto-shutdown (stop/delete/recycle), provides cleanup. Includes `/qovery-preview` slash command |
 | **qovery-terraform** | Generate Terraform manifests from an existing Qovery setup — reads config from API, generates HCL (qovery/qovery provider), imports resources into state, validates in test clone. Supports single or multiple environments. Safe: never applies to original without confirmation |
+| **qovery-cluster-ops** | Diagnose and tune cluster infrastructure: node churn diagnosis, pods stuck in Pending, Karpenter node pool tuning (consolidation, instance requirements, limits, spot), disruption resilience (PDBs, multi-AZ), and Kubernetes upgrade preparation |
 
 > **Looking for Remote Development Environments (RDEs)?** RDEs are now managed directly via [rde.qovery.com](https://rde.qovery.com). See the [RDE documentation](https://www.qovery.com/docs/getting-started/quickstart/remote-dev-environments) to get started.
 
 ## Quick Install
 
-**One command — installs all eight skills globally for all your projects:**
+**One command — installs all nine skills globally for all your projects:**
 
 ```bash
 curl -fsSL https://skill.qovery.com/install.sh | bash
@@ -40,7 +41,7 @@ curl -fsSL https://skill.qovery.com/install.sh | bash -s -- --project
 curl -fsSL https://skill.qovery.com/install.sh | bash -s -- --uninstall
 ```
 
-That's it. The installer automatically places all eight skills (with their `reference/`, `templates/`, and `examples/` sub-directories) in all the right locations so they're discovered by any compatible tool.
+That's it. The installer automatically places all nine skills (with their `reference/`, `templates/`, and `examples/` sub-directories) in all the right locations so they're discovered by any compatible tool.
 
 **Update to the latest version** — just run the install command again. It overwrites the previous versions:
 
@@ -220,6 +221,15 @@ The onboard skill acts as your personal cloud architect. The deploy skill handle
 - _"Generate Terraform from my existing project"_
 - `/qovery-terraform` (slash command)
 
+**Prompts that trigger qovery-cluster-ops:**
+- _"My nodes keep getting replaced"_
+- _"Karpenter is killing my pods"_
+- _"Pods are stuck in Pending"_
+- _"My cluster never scales down"_
+- _"Configure the Karpenter node pools"_
+- _"When is my Kubernetes version upgraded?"_
+- `/qovery-cluster-ops` (slash command)
+
 ## Slash Commands
 
 Each skill includes a slash command for quick invocation. Type `/` followed by the command name in your AI tool's chat:
@@ -234,6 +244,7 @@ Each skill includes a slash command for quick invocation. Type `/` followed by t
 | `/qovery-speedup` | Analyze and fix deployment bottlenecks | `/qovery-speedup` or `/qovery-speedup my-service` |
 | `/qovery-preview` | Create a preview environment for a PR | `/qovery-preview` or `/qovery-preview PR-123` |
 | `/qovery-terraform` | Generate Terraform from existing Qovery setup | `/qovery-terraform` or `/qovery-terraform https://console.qovery.com/...` |
+| `/qovery-cluster-ops` | Diagnose and tune cluster nodes and Karpenter | `/qovery-cluster-ops` or `/qovery-cluster-ops my-cluster` |
 
 Commands are installed automatically by the install script. They accept optional arguments (service name, environment name, Console URL) and auto-detect context from your git workspace.
 
@@ -376,16 +387,16 @@ git clone https://github.com/Qovery/qovery-skills.git
 cd qovery-skills
 
 # Global install (pick the paths for your tools)
-mkdir -p ~/.claude/skills && cp -r qovery qovery-onboard qovery-deploy qovery-troubleshoot qovery-optimize qovery-speedup qovery-preview qovery-terraform ~/.claude/skills/
-mkdir -p ~/.config/opencode/skills && cp -r qovery qovery-onboard qovery-deploy qovery-troubleshoot qovery-optimize qovery-speedup qovery-preview qovery-terraform ~/.config/opencode/skills/
-mkdir -p ~/.agents/skills && cp -r qovery qovery-onboard qovery-deploy qovery-troubleshoot qovery-optimize qovery-speedup qovery-preview qovery-terraform ~/.agents/skills/
+mkdir -p ~/.claude/skills && cp -r qovery qovery-onboard qovery-deploy qovery-troubleshoot qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-cluster-ops ~/.claude/skills/
+mkdir -p ~/.config/opencode/skills && cp -r qovery qovery-onboard qovery-deploy qovery-troubleshoot qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-cluster-ops ~/.config/opencode/skills/
+mkdir -p ~/.agents/skills && cp -r qovery qovery-onboard qovery-deploy qovery-troubleshoot qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-cluster-ops ~/.agents/skills/
 
 # Install all slash commands (Claude Code, OpenCode, etc.)
 mkdir -p ~/.claude/commands && cp qovery-*/commands/*.md ~/.claude/commands/
 mkdir -p ~/.config/opencode/commands && cp qovery-*/commands/*.md ~/.config/opencode/commands/
 
 # Or project-local install
-mkdir -p .claude/skills && cp -r qovery qovery-onboard qovery-deploy qovery-troubleshoot qovery-optimize qovery-speedup qovery-preview qovery-terraform .claude/skills/
+mkdir -p .claude/skills && cp -r qovery qovery-onboard qovery-deploy qovery-troubleshoot qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-cluster-ops .claude/skills/
 ```
 
 Verify the skills are discovered by checking if your tool lists all eight Qovery skills.

--- a/evals/qovery-cluster-ops.json
+++ b/evals/qovery-cluster-ops.json
@@ -1,0 +1,49 @@
+[
+  {
+    "skills": ["qovery-cluster-ops"],
+    "query": "My nodes keep getting replaced every few minutes and my pods restart even though the apps don't crash",
+    "files": [],
+    "expected_behavior": [
+      "Identifies the cluster and checks the KARPENTER feature via GET /organization/{orgId}/cluster/{clusterId}",
+      "Fetches the kubeconfig (qovery cluster kubeconfig) and sorts nodes by creationTimestamp to quantify churn",
+      "Loads reference/phase3-diagnose.md playbook 3.1 and inspects disruption/consolidation events",
+      "Distinguishes root causes: aggressive consolidate_after vs sensitive pods on the default pool vs narrow instance requirements vs spot interruptions",
+      "Proposes a concrete fix from reference/phase4-karpenter-tuning.md (e.g. raise consolidate_after on default_override) and applies it via PUT cluster + cluster deploy, then re-measures churn against the baseline"
+    ]
+  },
+  {
+    "skills": ["qovery-cluster-ops"],
+    "query": "My cluster never scales down after traffic drops — I'm paying for idle nodes all night",
+    "files": [],
+    "expected_behavior": [
+      "Loads reference/phase3-diagnose.md playbook 3.2 (consolidation blocked)",
+      "Checks nodepool disruption settings and looks for Unconsolidatable / blocked-disruption events",
+      "Identifies blockers: over-strict PDBs, do-not-disrupt pods, bare pods, single locked InstanceSize, or over-requested apps",
+      "Routes app right-sizing findings to qovery-optimize instead of fixing them here",
+      "For cluster-side causes, proposes changes in the KARPENTER feature (widen requirements, tune stable pool consolidation window) and applies via Console/API + cluster update"
+    ]
+  },
+  {
+    "skills": ["qovery-cluster-ops"],
+    "query": "Pods have been stuck in Pending for 30 minutes on my Qovery cluster",
+    "files": [],
+    "expected_behavior": [
+      "Lists Pending pods and reads the FailedScheduling message verbatim via kubectl describe",
+      "Loads reference/phase3-diagnose.md playbook 3.3 and maps the message to a cause (pool limits reached, arch mismatch, untolerated taint, Karpenter unhealthy)",
+      "Checks node pool limits and requirements in the KARPENTER feature before proposing a fix",
+      "If Karpenter creates no nodeclaim at all, prepares an escalation to Qovery support using reference/report-template.md instead of guessing"
+    ]
+  },
+  {
+    "skills": ["qovery-cluster-ops"],
+    "query": "Restrict my cluster to m5 and m6i instances and set a consolidation window on the stable pool for Saturday night",
+    "files": [],
+    "expected_behavior": [
+      "Reads the current KARPENTER feature value before modifying anything",
+      "Builds qovery_node_pools.requirements with InstanceFamily In [m5, m6i] and warns against locking a single InstanceSize",
+      "Sets stable_override.consolidation with enabled=true, days=[SATURDAY], start_time in PThh:mm format and a duration in PThhHmmM format",
+      "Applies via PUT /organization/{orgId}/cluster/{clusterId} then POST .../deploy (or flags Terraform-managed clusters to change the qovery_cluster resource instead)",
+      "Warns that requirement changes cause rolling node replacement and verifies the new values on the cluster afterwards"
+    ]
+  }
+]

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # https://github.com/Qovery/qovery-skills
 # ============================================================
 
-SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform")
+SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform" "qovery-cluster-ops")
 TARBALL_URL="https://codeload.github.com/Qovery/qovery-skills/tar.gz/refs/heads/main"
 
 # Colors (if terminal supports them)

--- a/local-install.sh
+++ b/local-install.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # https://github.com/Qovery/qovery-skills
 # ============================================================
 
-SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform")
+SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform" "qovery-cluster-ops")
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Colors (if terminal supports them)

--- a/qovery-cluster-ops/SKILL.md
+++ b/qovery-cluster-ops/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: qovery-cluster-ops
+description: Diagnoses and tunes Qovery cluster infrastructure. Covers node churn diagnosis, pods stuck in Pending, Karpenter node pool tuning (consolidation windows, consolidate_after, instance type requirements, limits, spot, node disks), disruption resilience (PDBs, do-not-disrupt, multi-AZ spread), and Kubernetes version upgrades. Works through the Qovery API, CLI, and kubectl. Use when the user reports node churn or node-level instability, pods stuck in Pending, asks to tune Karpenter or cluster resources, or prepares a Kubernetes upgrade on Qovery. (For application right-sizing use qovery-optimize; for failing deployments use qovery-troubleshoot; for slow deployments use qovery-speedup.)
+license: MIT
+compatibility: opencode
+metadata:
+  audience: platform-engineers
+  workflow: cluster-operations
+---
+
+# Qovery Cluster Ops Skill
+
+This skill operates the infrastructure layer of a Qovery cluster: nodes, Karpenter node pools, disruption behavior, and Kubernetes versions. It diagnoses node-level problems (churn, pending pods, node pressure), tunes the Karpenter configuration through the Qovery API, and verifies the result on the live cluster.
+
+Scope boundaries:
+- Application-level right-sizing and cost reports: `qovery-optimize`
+- A deployment that fails or an app that crashes: `qovery-troubleshoot`
+- Slow builds and deployments: `qovery-speedup`
+
+Karpenter tuning applies to AWS EKS clusters with the Karpenter feature enabled. On GCP, Azure, and Scaleway, node autoscaling is managed by the provider; only Phases 1, 2, 5, and 6 apply there.
+
+## When to Use This Skill
+
+Trigger phrases:
+- "My nodes keep getting recreated / replaced"
+- "Karpenter is killing my pods"
+- "My pods restart for no reason" (when app logs show no crash)
+- "Pods are stuck in Pending"
+- "Consolidation is too aggressive" / "my cluster never scales down"
+- "Configure the Karpenter node pools"
+- "Limit the instance types on my cluster"
+- "When is my Kubernetes version upgraded?"
+- `/qovery-cluster-ops` (slash command)
+
+## Workflow checklist
+
+```
+Cluster Ops Progress:
+- [ ] Phase 1 - Context & access (goal, cluster ID, provider, kubeconfig)
+- [ ] Phase 2 - Inspect (nodes, utilization, Karpenter node pools, events)
+- [ ] Phase 3 - Diagnose (churn, blocked consolidation, pending pods, node pressure)
+- [ ] Phase 4 - Tune Karpenter node pools & apply (API/Console + cluster update)
+- [ ] Phase 5 - Resilience review (PDBs, do-not-disrupt, stable pool, multi-AZ)
+- [ ] Phase 6 - Kubernetes upgrades (managed vs self-managed, preparation)
+- [ ] Phase 7 - Report findings and verify after change
+```
+
+Not every phase runs every time. Phase 1 decides the path:
+- Node churn / instability complaint → Phases 2, 3, 4, 5
+- Configuration request ("set up node pools") → Phases 2, 4
+- Pending pods → Phases 2, 3
+- Upgrade question → Phase 6
+
+## Reference materials (load on demand)
+
+| Phase | File | Purpose |
+|---|---|---|
+| Console URL | [reference/console-url-detection.md](reference/console-url-detection.md) | Extract IDs from a Qovery Console URL |
+| Auth | [reference/auth.md](reference/auth.md) | API token flow |
+| Phase 1 | [reference/phase1-context-access.md](reference/phase1-context-access.md) | Goal triage, cluster identification, kubeconfig, provider check |
+| Phase 2 | [reference/phase2-inspect.md](reference/phase2-inspect.md) | Node inventory, utilization, Karpenter state, churn measurement |
+| Phase 3 | [reference/phase3-diagnose.md](reference/phase3-diagnose.md) | Playbooks: churn, blocked consolidation, pending pods, node pressure, spot |
+| Phase 4 | [reference/phase4-karpenter-tuning.md](reference/phase4-karpenter-tuning.md) | Karpenter feature fields, node pool model, safe changes, apply & verify |
+| Phase 5 | [reference/phase5-resilience.md](reference/phase5-resilience.md) | PDBs, do-not-disrupt, stable pool placement, multi-AZ spread |
+| Phase 6 | [reference/phase6-upgrades.md](reference/phase6-upgrades.md) | Kubernetes version upgrades: managed vs self-managed, prep checklist |
+| Phase 7 | [reference/report-template.md](reference/report-template.md) | Cluster ops report template (findings, changes, verification) |
+
+## Quick reference
+
+### API endpoints
+
+```
+# Cluster configuration (features incl. Karpenter node pools)
+GET  /organization/{organizationId}/cluster                       # list clusters
+GET  /organization/{organizationId}/cluster/{clusterId}
+PUT  /organization/{organizationId}/cluster/{clusterId}           # edit features
+
+# Apply a configuration change (cluster update)
+POST /organization/{organizationId}/cluster/{clusterId}/deploy
+
+# Observability
+GET  /organization/{organizationId}/cluster/{clusterId}/status
+GET  /organization/{organizationId}/cluster/{clusterId}/logs
+GET  /cluster/{clusterId}/metrics
+
+# Access & settings
+GET  /organization/{organizationId}/cluster/{clusterId}/kubeconfig
+GET  /organization/{organizationId}/cluster/{clusterId}/advancedSettings
+PUT  /organization/{organizationId}/cluster/{clusterId}/advancedSettings
+```
+
+### CLI commands
+
+```bash
+qovery cluster list                          # clusters + status
+qovery cluster list-nodes --cluster-id <id>  # node names
+qovery cluster kubeconfig --cluster-id <id>  # writes kubeconfig file into the CURRENT directory
+qovery cluster deploy --cluster-id <id>      # apply pending configuration changes
+qovery cluster debug-pod                     # spawn a debug pod on the cluster
+```
+
+### kubectl (after fetching the kubeconfig)
+
+```bash
+kubectl get nodes --sort-by=.metadata.creationTimestamp   # node age = churn signal
+kubectl top nodes                                          # live utilization
+kubectl get nodepools,nodeclaims                           # Karpenter objects (AWS)
+kubectl get pods -A --field-selector status.phase=Pending  # unschedulable pods
+kubectl get events -A --sort-by=.lastTimestamp | grep -iE 'karpenter|nodeclaim|evict|drain'
+```
+
+## Reference links
+
+- **Clusters Docs**: <https://www.qovery.com/docs/getting-started/installation/kubernetes>
+- **Cluster Metrics API**: <https://www.qovery.com/docs/api-reference/clusters/fetch-cluster-metrics>
+- **CLI Commands**: <https://www.qovery.com/docs/cli/commands/overview>
+- **Karpenter Docs (upstream)**: <https://karpenter.sh/docs/>
+- **Qovery Optimize Skill**: <https://github.com/Qovery/qovery-skills>
+- **Qovery Troubleshoot Skill**: <https://github.com/Qovery/qovery-skills>
+- **Qovery Support**: <support@qovery.com>

--- a/qovery-cluster-ops/commands/qovery-cluster-ops.md
+++ b/qovery-cluster-ops/commands/qovery-cluster-ops.md
@@ -1,0 +1,13 @@
+---
+description: Diagnose and tune Qovery cluster infrastructure (nodes, Karpenter, upgrades)
+---
+
+Operate the infrastructure layer of a Qovery cluster: diagnose node churn or pending pods, tune Karpenter node pools, review disruption resilience, or prepare a Kubernetes upgrade.
+
+If arguments are provided, use them as context:
+- `$ARGUMENTS` - cluster name, Qovery Console URL, or a symptom description
+
+Follow the qovery-cluster-ops skill: identify the cluster and goal, inspect nodes and Karpenter state, run the matching diagnosis playbook, and apply configuration changes through the Qovery API followed by a cluster update.
+
+Current branch: !`git branch --show-current 2>/dev/null || echo "unknown"`
+Git remote: !`git remote get-url origin 2>/dev/null || echo "unknown"`

--- a/qovery-cluster-ops/reference/auth.md
+++ b/qovery-cluster-ops/reference/auth.md
@@ -1,0 +1,92 @@
+# Qovery Authentication
+
+## Security — Token Handling Rules
+
+**CRITICAL: NEVER display, log, print, or capture Qovery token values.**
+
+- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+  ```bash
+  # CORRECT — token is inline, never shown:
+  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+
+  # WRONG — token value would appear in output:
+  qovery auth token --print
+  echo $(qovery auth token --print)
+  export TOKEN=$(qovery auth token --print)
+  ```
+- NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
+- NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
+- NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
+- NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
+- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
+- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+
+## Qovery API Request Rules — User-Agent
+
+**Every `curl` request to the Qovery API (`api.qovery.com`) MUST include a User-Agent header identifying the skill and version.**
+
+The version is read from `_version.txt` (written at install time by `install.sh`). When executing curl commands, the agent MUST add this header:
+
+```bash
+# Read the version (do this once per session):
+QOVERY_SKILLS_VERSION=$(cat _version.txt 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+# Add to every curl command:
+-H "User-Agent: QoverySkill/auth (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)"
+```
+
+Full example:
+```bash
+curl -s \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/auth (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  https://api.qovery.com/organization
+```
+
+This applies to ALL curl commands targeting `api.qovery.com` — even when reference file examples don't explicitly show the User-Agent header. The agent MUST add it to every request it executes. Use `auth` as the context for the shared auth flow. When executing curl commands from a specific skill's reference files, use that skill's name instead (e.g., `qovery-deploy`, `qovery-troubleshoot`).
+
+---
+
+## 1. Existing API token in environment
+
+```bash
+# Check if a token is available (without printing it):
+test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
+```
+
+If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
+
+## 2. CLI already authenticated (`qovery auth token`)
+
+```bash
+# Check if the CLI is authenticated (without printing the token):
+qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+```
+
+If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+
+```bash
+# Token flows through the shell but is never visible to the agent:
+curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+```
+
+Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+
+```bash
+# Create the token and store it directly in .env (not displayed):
+qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
+# The user should manually export it or add it to their secure env config
+echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+```
+
+## 3. Interactive login
+
+If neither of the above works, prompt the user:
+
+```bash
+qovery auth                      # interactive browser login
+# OR for headless:
+# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+```
+
+After login, fall through to step 2 to obtain a token.

--- a/qovery-cluster-ops/reference/console-url-detection.md
+++ b/qovery-cluster-ops/reference/console-url-detection.md
@@ -1,0 +1,58 @@
+# Qovery Console URL Detection
+
+When the user provides a Qovery Console URL (from `console.qovery.com` or
+`new-console.qovery.com`), extract the resource IDs directly from the URL path.
+This saves significant back-and-forth — no need to ask which organization,
+project, environment, or service the user means.
+
+## URL format
+
+```
+https://{console.qovery.com|new-console.qovery.com}/organization/{orgId}/project/{projectId}/environment/{envId}/service/{serviceId}[/{page}]
+```
+
+## Extraction rules
+
+- `orgId` — UUID after `/organization/`
+- `projectId` — UUID after `/project/`
+- `envId` — UUID after `/environment/`
+- `serviceId` — UUID after `/service/`
+- `page` — optional suffix (`service-logs`, `deployment-logs`, `general`, `variables`, `settings`, etc.) gives context about what the user is viewing
+
+Not every URL contains all segments. Use whatever IDs are present:
+
+- URL with only `orgId` → organization is known, still ask about project/environment/service
+- URL with `orgId` + `projectId` + `envId` → environment is known, may still need service selection
+- URL with all four IDs → fully resolved, proceed directly
+
+## Resolving names from IDs
+
+After extracting IDs, resolve names via the API to confirm with the user:
+
+```bash
+# Organization name
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq '.results[] | select(.id == "{orgId}") | {id, name}'
+
+# Project name
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/project/{projectId}" | jq '{id, name}'
+
+# Environment name + all service names/statuses in one call
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}/statuses" | jq '{
+    environment: .environment.state,
+    applications: [.applications[] | {id, name: .name, state}],
+    containers: [.containers[] | {id, name: .name, state}],
+    databases: [.databases[] | {id, name: .name, state}],
+    jobs: [.jobs[] | {id, name: .name, state}],
+    helms: [.helms[] | {id, name: .name, state}]
+  }'
+
+# Cluster ID from the environment (the environment knows its cluster)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}" | jq '{cluster_id: .cluster_id}'
+```
+
+Use the extracted IDs directly in all subsequent API calls and skip any
+discovery questions for resources already identified by the URL.

--- a/qovery-cluster-ops/reference/phase1-context-access.md
+++ b/qovery-cluster-ops/reference/phase1-context-access.md
@@ -1,0 +1,75 @@
+# Phase 1: Context & Access
+
+## 1.1 Triage the goal
+
+Ask (or infer from the request) which path applies:
+
+| User says | Path |
+|---|---|
+| "Nodes keep getting replaced", "pods restart with no crash", "Karpenter kills my pods" | Churn diagnosis → Phases 2, 3, then 4/5 for the fix |
+| "Pods stuck in Pending", "deployment waits forever for a node" | Scheduling diagnosis → Phases 2, 3 |
+| "Configure node pools", "restrict instance types", "enable spot", "consolidation schedule" | Configuration → Phases 2, 4 |
+| "Cluster never scales down", "too many nodes for the load" | Consolidation diagnosis → Phases 2, 3, 4 |
+| "Kubernetes upgrade", "version EOL", "when do I get 1.xx?" | Upgrades → Phase 6 |
+| "Is my cluster resilient?", "what happens when a node dies?" | Resilience review → Phases 2, 5 |
+
+If the actual problem is a failing deployment or a crashing app, hand off to `qovery-troubleshoot`. If the goal is lowering the bill through app resources, hand off to `qovery-optimize`.
+
+## 1.2 Identify organization and cluster
+
+If the user pasted a Console URL, extract the IDs (see the console-url-detection reference). Otherwise:
+
+```bash
+qovery cluster list
+```
+
+Or via API:
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization/{organizationId}/cluster" | \
+  jq '.results[] | {id, name, cloud_provider, region, status, kubernetes_version: .version}'
+```
+
+Record: `organizationId`, `clusterId`, cloud provider, region, current status.
+
+## 1.3 Check the provider and the Karpenter feature
+
+Karpenter node pool tuning (Phase 4) only exists on **AWS EKS clusters with the KARPENTER feature enabled**. Check:
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization/{organizationId}/cluster/{clusterId}" | \
+  jq '.features[] | select(.id == "KARPENTER")'
+```
+
+- Feature present → full workflow available.
+- AWS without Karpenter (legacy node groups) → Phases 2, 3, 5, 6 apply; node sizing is controlled by `min_running_nodes` / `max_running_nodes` / `instance_type` on the cluster object instead.
+- GCP / Azure / Scaleway → node autoscaling is provider-managed. Phases 2, 3 (scheduling parts), 5, and 6 apply.
+
+## 1.4 Get kubectl access
+
+Live node inspection needs a kubeconfig:
+
+```bash
+qovery cluster kubeconfig --cluster-id {clusterId}
+```
+
+IMPORTANT: this writes the kubeconfig file into the **current working directory**. Run it from a scratch directory, then:
+
+```bash
+export KUBECONFIG="$PWD/kubeconfig-{clusterId}.yaml"   # use the actual filename printed by the CLI
+kubectl get nodes
+```
+
+If the user cannot access the cluster directly (restricted network, no kubectl), fall back to:
+- `GET /cluster/{clusterId}/metrics` for utilization
+- `GET /organization/{organizationId}/cluster/{clusterId}/logs` for infrastructure logs
+- `qovery cluster debug-pod` for an in-cluster shell
+
+## 1.5 Capture the baseline
+
+Before changing anything, note in the working report (Phase 7 template):
+- Cluster status and Kubernetes version
+- Node count right now
+- The user's symptom in one sentence and when it started

--- a/qovery-cluster-ops/reference/phase2-inspect.md
+++ b/qovery-cluster-ops/reference/phase2-inspect.md
@@ -1,0 +1,77 @@
+# Phase 2: Inspect the Cluster
+
+Collect facts before diagnosing. All kubectl commands assume the kubeconfig from Phase 1.
+
+## 2.1 Node inventory and age distribution
+
+```bash
+kubectl get nodes --sort-by=.metadata.creationTimestamp \
+  -o custom-columns='NAME:.metadata.name,AGE:.metadata.creationTimestamp,TYPE:.metadata.labels.node\.kubernetes\.io/instance-type,ZONE:.metadata.labels.topology\.kubernetes\.io/zone,CAPACITY-TYPE:.metadata.labels.karpenter\.sh/capacity-type,NODEPOOL:.metadata.labels.karpenter\.sh/nodepool'
+```
+
+Read the age column as a churn signal:
+- Most nodes younger than a few hours on a steady workload → churn is likely abnormal, go to Phase 3.1.
+- A healthy steady-state cluster shows a mix of old and young nodes.
+
+Also note: instance type diversity, zone spread (needed in Phase 5), spot vs on-demand mix (`CAPACITY-TYPE`), and which Karpenter node pool each node belongs to (typically `default` and `stable` on Qovery clusters).
+
+## 2.2 Utilization
+
+```bash
+kubectl top nodes          # live CPU/memory usage (needs metrics-server, present on Qovery clusters)
+kubectl describe nodes | grep -A6 'Allocated resources'   # requested vs allocatable
+```
+
+Distinguish the two numbers per node:
+- **Requests vs allocatable**: what the scheduler and Karpenter consolidation reason about.
+- **Usage (top)**: what the workloads actually consume.
+
+High requests + low usage → over-requested apps (that fix belongs to `qovery-optimize`, note it in the report). High memory usage (>85%) across nodes → node pressure, go to Phase 3.4.
+
+No kubectl access? Use `GET /cluster/{clusterId}/metrics` instead.
+
+## 2.3 Karpenter state (AWS with Karpenter)
+
+```bash
+kubectl get nodepools
+kubectl get nodeclaims -o wide          # one per provisioned node; STATUS + AGE
+kubectl describe nodepool default       # current requirements, disruption settings, limits
+kubectl describe nodepool stable
+```
+
+Check on each node pool:
+- `spec.disruption.consolidateAfter` and consolidation policy
+- `spec.template.spec.requirements` (instance families, sizes, arch, capacity type)
+- `spec.limits` (cpu/memory caps) and current usage vs limit in `status.resources`
+
+A node pool at its `limits` cannot provision new nodes: pods stay Pending even though Karpenter is healthy.
+
+## 2.4 Recent disruption and scheduling events
+
+```bash
+kubectl get events -A --sort-by=.lastTimestamp | grep -iE 'karpenter|nodeclaim|drain|evict|FailedScheduling' | tail -50
+```
+
+Classify what you see:
+- `DisruptionTerminating`, `Unconsolidatable`, consolidation messages → feed Phase 3.1/3.2
+- `FailedScheduling` with reasons (insufficient cpu/memory, node affinity, taints) → feed Phase 3.3
+- Spot interruption / rebalance messages → feed Phase 3.5
+
+## 2.5 Churn measurement (make it a number)
+
+Count node creations over a window so before/after comparison is possible:
+
+```bash
+kubectl get nodeclaims -o json | jq -r '.items[].metadata.creationTimestamp' | sort | uniq -c
+```
+
+Report churn as "N node replacements in the last 24h for a steady workload of M pods". More than a handful of replacements per day without deploys or traffic changes is worth diagnosing.
+
+## 2.6 Infrastructure logs (API view)
+
+For events kubectl cannot show (cluster provisioning, upgrade activity):
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization/{organizationId}/cluster/{clusterId}/logs" | jq '.results[-20:]'
+```

--- a/qovery-cluster-ops/reference/phase3-diagnose.md
+++ b/qovery-cluster-ops/reference/phase3-diagnose.md
@@ -1,0 +1,95 @@
+# Phase 3: Diagnosis Playbooks
+
+Pick the playbook matching the Phase 2 findings. Each ends with a pointer to the fix.
+
+## 3.1 Playbook: Node churn too high
+
+**Symptoms:** nodes replaced many times a day, pods restarted without app crashes, monitoring/telemetry gaps, users report random disconnections.
+
+**Checks:**
+1. Which pool churns? Compare nodeclaim ages per `karpenter.sh/nodepool` label (Phase 2.1).
+2. Why are nodes removed? Look for consolidation events on the terminated nodeclaims:
+   ```bash
+   kubectl get events -A --sort-by=.lastTimestamp | grep -iE 'consolidat|disrupt' | tail -30
+   ```
+3. Is the workload itself flapping? HPA scaling up/down repeatedly forces node add/remove cycles:
+   ```bash
+   kubectl get hpa -A
+   kubectl get events -A | grep -i 'ScalingReplicaSet' | tail -20
+   ```
+
+**Root causes and fixes:**
+
+| Cause | Evidence | Fix |
+|---|---|---|
+| Consolidation too aggressive on the `default` pool | Nodes killed minutes after becoming underutilized | Raise `consolidate_after` (Phase 4.3) |
+| Sensitive workloads on the consolidating pool | Single-replica or stateful pods on `default` pool nodes | Move them to the `stable` pool / add do-not-disrupt (Phase 5) |
+| Workload flapping (HPA min too low, spiky traffic) | Scaling events correlate with node churn | Raise HPA min replicas; smooth the workload first, then retune |
+| Requirements too narrow for bin-packing | One instance size allowed, Karpenter replaces nodes to fit pods | Widen instance requirements (Phase 4.4) |
+| Spot interruptions | Interruption/rebalance events, churn only on `capacity-type=spot` nodes | See 3.5 |
+
+## 3.2 Playbook: Consolidation not happening (cluster never scales down)
+
+**Symptoms:** node count stays high after load drops; utilization per node is low; cost creep.
+
+**Checks:**
+1. `kubectl describe nodepool default` → is consolidation configured as expected?
+2. Look for `Unconsolidatable` / blocked-disruption events and read the reason:
+   ```bash
+   kubectl get events -A | grep -iE 'unconsolidatable|cannot disrupt|blocked' | tail -20
+   ```
+
+**Root causes:**
+
+| Blocker | Evidence | Fix |
+|---|---|---|
+| PDB allows zero disruption | Event names the PDB | Fix `maxUnavailable`/`minAvailable` (Phase 5.1) |
+| `karpenter.sh/do-not-disrupt` pods spread across nodes | Annotation present on pods | Confine them to the `stable` pool (Phase 5.2) |
+| Pods without a controller (bare pods) | Bare pods on the node | Recreate them as Deployments/Jobs |
+| Stable pool outside its consolidation window | Churn-free by design | Expected; tune the window if needed (Phase 4.3) |
+| Instance requirements lock the size | Only one size allowed, so replacing 2 half-empty nodes with 1 bigger one is impossible | Widen `InstanceSize`/`InstanceFamily` requirements (Phase 4.4) |
+| Over-requested apps | Requests >> usage, nodes look "full" to the scheduler | Right-size requests via `qovery-optimize`, then consolidation resumes |
+
+## 3.3 Playbook: Pods stuck in Pending
+
+**Symptoms:** deployments hang at scheduling, `FailedScheduling` events.
+
+**Checks:**
+```bash
+kubectl get pods -A --field-selector status.phase=Pending
+kubectl describe pod {pod} -n {ns}    # read the FailedScheduling message verbatim
+```
+
+**Root causes by message:**
+
+| Message contains | Cause | Fix |
+|---|---|---|
+| `Insufficient cpu` / `Insufficient memory` + no new node appears | Node pool at its `limits`, or requirements match no instance type large enough | Raise pool limits or widen requirements (Phase 4.4/4.5) |
+| `didn't match Pod's node affinity/selector` | Pod requires arch/labels no pool provides (e.g. ARM64 image on AMD64-only pool) | Align `default_service_architecture` / requirements with the workload |
+| `untolerated taint` | GPU/dedicated pool taints | Add the toleration or target the right pool |
+| Nothing happens at all, no nodeclaim created | Karpenter itself unhealthy, or subnet/IP exhaustion | Check karpenter controller logs; escalate to Qovery support with cluster logs |
+| New node appears but takes 2-5 min | Normal provisioning latency | Expected on scale-up; see `qovery-speedup` if it hurts deployments |
+
+## 3.4 Playbook: Node memory pressure
+
+**Symptoms:** OOM kills without app memory growth, node `MemoryPressure=True`, system pods evicted.
+
+**Checks:**
+```bash
+kubectl describe nodes | grep -B2 -A5 'MemoryPressure'
+kubectl top nodes
+```
+
+**Root causes:** apps with memory limits far above requests (overcommit), or instance types too small for the pod mix. Fixes: align requests with real usage (`qovery-optimize`), or require larger instance sizes on the pool (Phase 4.4). Memory-saturated nodes also break consolidation: Karpenter cannot drain a node whose pods do not fit elsewhere.
+
+## 3.5 Playbook: Spot interruptions
+
+**Symptoms:** churn confined to `karpenter.sh/capacity-type=spot` nodes; AWS interruption notices in events.
+
+**Assess before "fixing":** spot churn is the accepted price of the discount. Act only if the workload cannot tolerate it:
+- Production, interruption-sensitive → keep those services on on-demand: the `stable` pool is on-demand; or disable `spot_enabled` on the cluster (Phase 4.6).
+- Tolerant workloads → diversify instance requirements instead: more families/sizes = lower interruption probability.
+
+## 3.6 When to escalate to Qovery support
+
+Escalate with the Phase 7 report when the evidence points to infrastructure Qovery manages: Karpenter controller crash-looping, cluster stuck in a deployment state, subnet/IP exhaustion, control-plane errors in cluster logs. Contact: support@qovery.com or the in-Console chat.

--- a/qovery-cluster-ops/reference/phase4-karpenter-tuning.md
+++ b/qovery-cluster-ops/reference/phase4-karpenter-tuning.md
@@ -1,0 +1,92 @@
+# Phase 4: Karpenter Node Pool Tuning
+
+Applies to AWS EKS clusters with the KARPENTER feature. All changes go through the Qovery cluster configuration (Console or API), never by editing Karpenter CRDs directly on the cluster: direct edits are overwritten on the next cluster update.
+
+## 4.1 The Qovery node pool model
+
+Qovery provisions Karpenter with managed node pools:
+
+| Pool | Purpose | Consolidation behavior |
+|---|---|---|
+| `default` | Regular workloads | Continuous, after `consolidate_after` |
+| `stable` | Workloads that must not be disrupted (single replica, stateful, databases in container mode) | Only inside an explicit scheduled window |
+| `gpu` (optional) | GPU workloads | Own requirements/limits |
+| cronjob override (optional) | Batch/cron workloads | Own limits/consolidate_after |
+
+The configuration lives in the cluster's KARPENTER feature (`ClusterFeatureKarpenterParameters`):
+
+```json
+{
+  "spot_enabled": true,
+  "disk_size_in_gib": 50,
+  "disk_iops": 3000,
+  "disk_throughput": 125,
+  "default_service_architecture": "AMD64",
+  "qovery_node_pools": {
+    "requirements": [
+      { "key": "InstanceFamily", "operator": "In", "values": ["t3", "m5", "m6i", "c5", "r5"] },
+      { "key": "InstanceSize",   "operator": "In", "values": ["large", "xlarge", "2xlarge"] },
+      { "key": "Arch",           "operator": "In", "values": ["AMD64"] }
+    ],
+    "default_override": {
+      "consolidate_after": "10m",
+      "limits": { "enabled": true, "max_cpu_in_vcpu": 200, "max_memory_in_gibibytes": 400, "max_gpu": 0 }
+    },
+    "stable_override": {
+      "consolidation": {
+        "enabled": true,
+        "days": ["SATURDAY", "SUNDAY"],
+        "start_time": "PT22:00",
+        "duration": "PT4H0M"
+      },
+      "limits": { "enabled": true, "max_cpu_in_vcpu": 100, "max_memory_in_gibibytes": 200, "max_gpu": 0 }
+    }
+  }
+}
+```
+
+Requirement keys: `InstanceFamily`, `InstanceSize`, `Arch` (plus `SkuFamily`/`SkuVersion` on Azure). Operator: `In`. In the Console this is **Cluster Settings > Resources**.
+
+## 4.2 Read the current configuration
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization/{organizationId}/cluster/{clusterId}" | \
+  jq '.features[] | select(.id == "KARPENTER") | .value'
+```
+
+## 4.3 Tune consolidation
+
+**`default` pool, `consolidate_after`** (string like `30s`, `10m`, `1h`; max `24h`): how long a node stays underutilized before Karpenter consolidates it.
+- Churn complaints → raise it (e.g. `30s` → `10m` or `30m`). Cost rises slightly; stability improves.
+- Cost complaints with slow scale-down → lower it, but not below the workload's natural oscillation period.
+
+**`stable` pool, consolidation window** (`consolidation` object): `enabled`, `days` (uppercase weekday names), `start_time` (ISO-8601 `PT22:00`), `duration` (`PT4H0M`).
+- Keep the window in the lowest-traffic period.
+- Window too short or disabled → the stable pool accumulates underutilized nodes forever; schedule at least a weekly window.
+
+## 4.4 Tune instance requirements
+
+Rules of thumb:
+- **Diversity beats precision.** 10-20 instance types across several families (`t3`, `m5`, `m6i`, `c5`, `r5`) gives Karpenter room to bin-pack and, with spot, lowers interruption rates.
+- **Never lock a single `InstanceSize`.** One size makes consolidation nearly impossible (it cannot swap two half-empty nodes for one larger one) and is a common root cause of both churn and cost creep.
+- Include at least one memory-optimized family (`r5`/`r6i`) if any workload is memory-heavy.
+- `Arch` must match what services build for; mixed-arch needs both values and multi-arch images.
+
+## 4.5 Tune limits
+
+`limits` caps the total vCPU/memory a pool can provision. A pool at its cap silently stops creating nodes (pods stay Pending, see Phase 3.3). Size caps to roughly 2x normal peak so autoscaling headroom survives incidents, and keep them enabled as a cost backstop.
+
+## 4.6 Spot and node disks
+
+- `spot_enabled`: cluster-level opt-in for spot capacity. Karpenter falls back to on-demand automatically when spot is unavailable. Disable only if the whole cluster is interruption-sensitive; otherwise handle sensitive services via the stable pool (Phase 5).
+- `disk_size_in_gib`, `disk_iops` (3000-16000), `disk_throughput` (125-1000 MB/s): raise when image pulls or ephemeral storage are the bottleneck (visible as `DiskPressure` or slow pulls in `qovery-speedup`).
+
+## 4.7 Apply and verify
+
+1. `PUT /organization/{organizationId}/cluster/{clusterId}` with the full cluster payload including the modified KARPENTER feature. Fetch the current object first and modify only the intended fields.
+2. Trigger the cluster update: `POST .../cluster/{clusterId}/deploy` or `qovery cluster deploy --cluster-id {clusterId}`. Warn the user: the update is rolling and safe, but node pool requirement changes cause node replacement as Karpenter converges.
+3. Watch: `qovery cluster list` until status is back to a deployed state; `kubectl describe nodepool default` to confirm the new values reached the cluster.
+4. Re-measure churn with the Phase 2.5 method over the next 24-48h and compare against the baseline recorded in Phase 1.5.
+
+Terraform-managed clusters: apply the same values in the `qovery_cluster` resource features instead of the API, otherwise the next `terraform apply` reverts the change.

--- a/qovery-cluster-ops/reference/phase5-resilience.md
+++ b/qovery-cluster-ops/reference/phase5-resilience.md
@@ -1,0 +1,49 @@
+# Phase 5: Resilience Review
+
+Node disruption (consolidation, spot, upgrades) is normal on an autoscaled cluster. Resilience means workloads tolerate it. Review these four layers.
+
+## 5.1 PodDisruptionBudgets
+
+```bash
+kubectl get pdb -A
+```
+
+Check both failure modes:
+- **Missing PDB** on multi-replica production services → a drain can evict all replicas at once. Add a PDB with `maxUnavailable: 1` (or equivalent).
+- **Over-strict PDB** (`maxUnavailable: 0`, or `minAvailable` equal to replica count) → blocks consolidation and Kubernetes upgrades entirely. This shows up as `Unconsolidatable` events (Phase 3.2) and stuck node drains. Relax it or scale replicas up by one.
+
+## 5.2 Protect disruption-sensitive workloads
+
+Two mechanisms, in order of preference on Qovery:
+
+1. **Stable node pool placement.** Qovery schedules single-replica services and container-mode databases on the `stable` pool, which only consolidates inside its scheduled window. Verify sensitive pods actually run there:
+   ```bash
+   kubectl get pods -n {ns} -o wide   # then check the node's karpenter.sh/nodepool label
+   ```
+2. **`karpenter.sh/do-not-disrupt: "true"` pod annotation** for exceptional cases (long-running jobs that must finish). Use sparingly: every annotated pod pins its node and degrades consolidation (Phase 3.2).
+
+## 5.3 Multi-AZ spread
+
+```bash
+kubectl get nodes -o custom-columns='NAME:.metadata.name,ZONE:.metadata.labels.topology\.kubernetes\.io/zone'
+kubectl get pods -n {ns} -o wide     # map replicas to zones for critical services
+```
+
+Flags to raise:
+- All nodes in one zone on a production cluster → zone outage takes everything down. Check the cluster's region/AZ configuration with Qovery support if this looks wrong.
+- All replicas of a critical service on nodes in the same zone → replicas exist but share the failure domain. Kubernetes spreads by default only loosely; verify what topology spread or anti-affinity options are available for the service (service advanced settings via `GET /application/{appId}/advancedSettings`) rather than assuming.
+
+Zonal data transfer has a cost: forcing spread on chatty internal services trades resilience for cross-AZ traffic charges. Say so when recommending it.
+
+## 5.4 Disruption tolerance checklist
+
+For each critical service, confirm:
+
+- [ ] At least 2 replicas (or deliberately accepted downtime, documented)
+- [ ] PDB present and satisfiable (5.1)
+- [ ] Graceful shutdown: handles SIGTERM, terminates within the grace period
+- [ ] Liveness/readiness probes correct, so replacements enter rotation cleanly
+- [ ] Single-replica/stateful services on the stable pool (5.2)
+- [ ] Not interruption-sensitive while running on spot nodes; move to on-demand/stable if it is
+
+Findings that are application configuration (replicas, probes) belong in the report as handoffs to `qovery-deploy`/`qovery-optimize` workflows rather than cluster changes.

--- a/qovery-cluster-ops/reference/phase6-upgrades.md
+++ b/qovery-cluster-ops/reference/phase6-upgrades.md
@@ -1,0 +1,32 @@
+# Phase 6: Kubernetes Version Upgrades
+
+## 6.1 Who upgrades what
+
+| Cluster type | Who runs the upgrade |
+|---|---|
+| Qovery-managed (EKS, GKE, AKS, Kapsule) | Qovery rolls out Kubernetes upgrades progressively across clusters; the customer does not trigger them |
+| Self-managed / BYOK (`qovery cluster install`) | The customer upgrades Kubernetes; Qovery components must remain compatible |
+
+Read the current version from `GET /organization/{organizationId}/cluster/{clusterId}` (or `qovery cluster list`). For questions about upgrade timing on managed clusters, check the changelog and status page (links in SKILL.md) or ask Qovery support; do not promise dates.
+
+## 6.2 Preparation checklist (managed clusters)
+
+The upgrade itself is Qovery's job, but workloads decide whether it is a non-event. Before a version bump:
+
+1. **Deprecated API usage.** Helm charts and operators the user deployed themselves (via Qovery Helm services or directly) may use APIs removed in the target version. Scan with a purpose-built tool if available in the environment (`pluto detect-helm -A`, `kubent`), otherwise review the charts' compatibility notes against the target Kubernetes version.
+2. **PDB sanity.** Upgrades drain every node; an unsatisfiable PDB stalls the rollout (same check as the resilience review, Phase 5.1).
+3. **Graceful shutdown.** Every node is replaced during an upgrade, so SIGTERM handling and probe correctness matter more than on a normal day.
+4. **Pinned node images or versions in user tooling.** Anything that hardcodes a Kubernetes minor version (CI kubectl, client libraries with skew limits) should be checked against the target version.
+
+## 6.3 During and after
+
+- Watch progress: `qovery cluster list` (status) and `GET .../cluster/{clusterId}/logs`.
+- Node-by-node replacement is expected; total node count temporarily rises.
+- After: `kubectl get nodes` shows the new version on every node; run a smoke check on critical services; re-check for pods stuck Pending (Phase 3.3), which after upgrades usually means an unsatisfiable PDB or a taint change.
+
+## 6.4 Self-managed clusters
+
+For BYOK clusters, the upgrade procedure belongs to the customer's distribution. The Qovery-side steps:
+1. Confirm the target version is supported by Qovery (docs/changelog, or support).
+2. Upgrade the cluster with the distribution's own tooling.
+3. Re-run `qovery cluster install` guidance if Qovery components need updating, and verify the cluster reports healthy in the Console afterwards.

--- a/qovery-cluster-ops/reference/report-template.md
+++ b/qovery-cluster-ops/reference/report-template.md
@@ -1,0 +1,50 @@
+# Cluster Ops Report Template
+
+Fill during the workflow; deliver at the end. Also the right artifact to attach when escalating to Qovery support (support@qovery.com).
+
+```markdown
+# Cluster Ops Report - {cluster name}
+
+**Cluster:** {name} ({clusterId}) - {provider} {region}, Kubernetes {version}
+**Date:** {date}
+**Requested by:** {user}
+**Symptom / goal:** {one sentence}
+
+## Baseline (before changes)
+
+| Metric | Value |
+|---|---|
+| Node count | {n} ({types}, {zones}) |
+| Node replacements last 24h | {n} |
+| Pending pods | {n} |
+| Avg node memory usage | {pct} |
+| Karpenter pools | default (consolidate_after={v}), stable (window={days} {start} {duration}) |
+
+## Findings
+
+1. {finding} - evidence: {command/event output reference}
+2. ...
+
+## Changes applied
+
+| Change | Where | Before | After |
+|---|---|---|---|
+| {e.g. consolidate_after} | KARPENTER feature, default_override | 30s | 10m |
+
+Applied via {Console / PUT + cluster deploy / Terraform}, cluster update completed at {time}.
+
+## Verification
+
+- {metric} re-measured over {window}: {before} → {after}
+
+## Not changed (handoffs)
+
+- {e.g. over-requested CPU on service X → qovery-optimize}
+- {e.g. missing PDB on service Y → application change}
+
+## Open questions for Qovery support (if escalating)
+
+- {question + the evidence that motivates it}
+```
+
+Keep raw command outputs referenced in Findings available (paste the relevant excerpts below the report or in an appendix section) so support can verify without re-running everything.

--- a/scripts/sync-shared.sh
+++ b/scripts/sync-shared.sh
@@ -11,8 +11,8 @@ cd "$REPO_ROOT"
 # Mapping: <source-under-_shared>  =>  <skill1> <skill2> ...
 # Each line: SRC | SKILL_LIST (space-separated)
 SYNC_MAP=$(cat <<'EOF'
-console-url-detection.md | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform
-auth.md                  | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform
+console-url-detection.md | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-cluster-ops
+auth.md                  | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-cluster-ops
 pricing/aws.md           | qovery-optimize
 pricing/gcp.md           | qovery-optimize
 pricing/azure.md         | qovery-optimize


### PR DESCRIPTION
## Why

Three recurring cluster support cases have no skill today: nodes replaced so often that pods restart without crashing, clusters that never scale down after load drops, and pods stuck in Pending because a node pool hit its limits. The existing skills stop at the application layer. qovery-optimize's own reference says "Verify Karpenter is consolidating properly" without saying how, and qovery-troubleshoot's layer 8 only checks that Karpenter can provision nodes. No skill encodes the actual diagnosis or the fix, so every case is re-investigated by hand.

## What

- Five diagnosis playbooks: node churn, blocked consolidation, pending pods, node memory pressure, spot interruptions
- Karpenter tuning through the KARPENTER cluster feature (consolidate_after, stable pool consolidation window, instance requirements, node pool limits, spot, node disks), applied via PUT cluster + cluster deploy. Editing CRDs directly is called out as wrong: the next cluster update overwrites them
- Resilience review: PDBs (both failure modes), do-not-disrupt, stable pool placement, multi-AZ spread
- Kubernetes upgrade guidance (managed vs self-managed) with a preparation checklist
- A report template that doubles as a support escalation dossier

Every API field comes from qovery-openapi-spec (ClusterFeatureKarpenterParameters, KarpenterNodePool* schemas) and every CLI command from the qovery-cli source.

## Why a separate skill, not an extension of qovery-troubleshoot

- Different entry point. Troubleshoot starts from a broken service. In most cluster-ops cases nothing is broken: deployments pass, apps run, but nodes churn or the bill creeps up. Half of this skill is proactive work (node pool configuration, resilience review, upgrade prep) with no incident to troubleshoot.
- Different fix surface. Troubleshoot edits service config: ports, probes, env vars, memory. Cluster-ops edits the cluster object and requires a cluster redeploy, with rolling node replacement as a side effect the user must be warned about.
- Trigger precision. Descriptions are how agents route requests. Folding node churn, Karpenter tuning and upgrades into troubleshoot's description would dilute both problem spaces and degrade routing. This keeps the existing split: troubleshoot (broken) / speedup (slow) / optimize (costly) / cluster-ops (unstable infra).
- Explicit handoffs both ways: troubleshoot's layer 8 stays a shallow check that routes here; cluster-ops routes app crashes to troubleshoot and over-requested resources to optimize.

## Structure

Follows the CLAUDE.md conventions: SKILL.md at 120 lines (triage, checklist, navigation table, quick reference), 7 self-contained reference files loaded on demand, slash command (reference only, not installed), 4 eval scenarios. No templates/scripts, so the User-Agent rule is covered by the _shared/auth.md runtime directive.

## Test plan

- [x] Every SKILL.md under 500 lines
- [x] All internal reference links resolve
- [x] No anti-patterns (2nd-person openers, time-sensitive content, AI trailers)
- [x] scripts/sync-shared.sh run after adding the skill to the sync map (auth.md, console-url-detection.md shipped into the skill)
- [x] local-install.sh smoke-tested in a throwaway HOME, installs the skill to all 3 locations
- [x] evals/qovery-cluster-ops.json valid and follows the authoring guidelines (golden path, variants, edge case)

## Reviewer notes

- Replaces #17, which was based on the stale refactor branch; this one is built on main's current layout (9 skills including qovery and qovery-terraform, README count updated to nine).
- Karpenter tuning is scoped to AWS EKS with the KARPENTER feature; on other providers the skill degrades explicitly to phases 1, 2, 5, 6.
- Registered everywhere CLAUDE.md requires: install.sh and local-install.sh SKILLS arrays, README (table row, trigger prompts, slash command table, manual cp lines), sync map.