### PR TITLE
feat(optimize): KRR right-sizing via cluster analysis when observability is on

### DIFF
--- a/evals/qovery-optimize.json
+++ b/evals/qovery-optimize.json
@@ -35,5 +35,18 @@
       "Recommends keeping production on MANAGED",
       "Applies the change per database after individual confirmation, not as a single batch action"
     ]
+  },
+  {
+    "skills": ["qovery-optimize"],
+    "query": "Right-size my production cluster — we have Qovery observability enabled, use real metrics",
+    "files": [],
+    "expected_behavior": [
+      "Checks metrics_parameters.enabled via GET /organization/{orgId}/cluster/{clusterId} before choosing the right-sizing method",
+      "Since observability is enabled, loads reference/phase2b-krr-rightsizing.md instead of hand-computing from the metrics API",
+      "Runs 'qovery cluster analysis cost-recommendation' with the Qovery flag set (P99 CPU, OOM-aware memory buffers, --allow-hpa) and only allowlisted --cmd-arg values",
+      "Does not fetch a kubeconfig or install KRR locally: the analysis runs server-side and is read-only",
+      "Maps KRR rows back to Qovery services and applies the Phase 2 guardrails (minimum thresholds, seasonal peaks, growth buffers)",
+      "Tags the recommendations as KRR-based in the Phase 3 report and falls back to Dimension 1 formulas if observability is off and no Prometheus URL is available"
+    ]
   }
 ]

--- a/qovery-optimize/SKILL.md
+++ b/qovery-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qovery-optimize
-description: Reduces Kubernetes cluster and application costs on Qovery. Analyzes historical resource consumption, factors in the user's business context (seasonal patterns, growth stage, reliability requirements), estimates external resource costs from public cloud pricing, and proposes right-sizing, autoscaling, environment scheduling, spot instances, and database mode changes. Generates a cost report with CSV export and applies changes via CLI+API or Terraform. Use when the user asks to reduce costs, right-size, or optimize Qovery resource spend.
+description: Reduces Kubernetes cluster and application costs on Qovery. Analyzes historical resource consumption, factors in the user's business context (seasonal patterns, growth stage, reliability requirements), estimates external resource costs from public cloud pricing, and proposes right-sizing, autoscaling, environment scheduling, spot instances, and database mode changes. When Qovery observability is enabled on the cluster, right-sizing uses KRR (Kubernetes Resource Recommender) for P99-based, OOM-aware per-container recommendations. Generates a cost report with CSV export and applies changes via CLI+API or Terraform. Use when the user asks to reduce costs, right-size, run KRR, or optimize Qovery resource spend.
 license: MIT
 compatibility: opencode
 metadata:
@@ -54,7 +54,7 @@ For slow deployments use `qovery-speedup`. For deployment failures use `qovery-t
 ```
 Cost Optimization Progress:
 - [ ] Phase 1 — Context gathering (auth, business context, resource metrics)
-- [ ] Phase 2 — Analysis across 7 optimization dimensions
+- [ ] Phase 2 — Analysis across 7 optimization dimensions (right-sizing via KRR when observability is enabled)
 - [ ] Phase 3 — Generate cost report (Markdown + CSV)
 - [ ] Phase 4 — Apply approved changes (CLI+API or Terraform) + USER CONFIRMATION per change
 - [ ] Phase 5 — Set up ongoing monitoring & follow-up
@@ -69,6 +69,7 @@ Cost Optimization Progress:
 | Auth | [reference/auth.md](reference/auth.md) | API token flow |
 | Phase 1 | [reference/phase1-context-gathering.md](reference/phase1-context-gathering.md) | Inventory, business context, resource metrics queries |
 | Phase 2 | [reference/phase2-optimization-dimensions.md](reference/phase2-optimization-dimensions.md) | Right-sizing, autoscaling, DB mode, scheduling, cluster, build, external resources |
+| Phase 2b | [reference/phase2b-krr-rightsizing.md](reference/phase2b-krr-rightsizing.md) | KRR-based right-sizing when Qovery observability is enabled (setup, run, guardrails) |
 | Phase 3 | [reference/phase3-cost-report.md](reference/phase3-cost-report.md) | Report template (Markdown + CSV) |
 | Phase 4 | [reference/phase4-apply-changes.md](reference/phase4-apply-changes.md) | CLI+API + Terraform application paths, with per-change confirmation |
 | Phase 5 | [reference/phase5-monitoring.md](reference/phase5-monitoring.md) | Ongoing dashboards, alert thresholds, follow-up cadence |
@@ -151,11 +152,14 @@ qovery cluster list                  # Cluster overview
 qovery service list                  # Service overview with resource info
 qovery status                        # Current status
 qovery application env list          # Check env var configuration
+qovery cluster analysis cost-recommendation -c <cluster-id>   # Server-side KRR right-sizing (observability required)
+qovery cluster analysis logs -c <cluster-id> -a <analysis-id> # Report of a past analysis
 ```
 
 ## Reference links
 
 - **Qovery Optimization Guide**: <https://www.qovery.com/docs/getting-started/guides/qovery-101/optimize>
+- **KRR (Kubernetes Resource Recommender)**: <https://github.com/robusta-dev/krr>
 - **Deployment Rules (Scheduling)**: <https://www.qovery.com/docs/configuration/deployment-rule>
 - **Kubecost Integration**: <https://www.qovery.com/docs/configuration/integrations/observability/kubecost>
 - **Copilot Optimization Capabilities**: <https://www.qovery.com/docs/copilot/capabilities/optimization>

--- a/qovery-optimize/reference/phase1-context-gathering.md
+++ b/qovery-optimize/reference/phase1-context-gathering.md
@@ -112,6 +112,14 @@ ASK the user these questions before running any analysis. Group them conversatio
 
 Collect actual resource consumption data. Default analysis period: **7 days** for real-time analysis, **30 days** for seasonal/trend analysis.
 
+**First, check whether Qovery observability is enabled on the cluster:**
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization/{organizationId}/cluster/{clusterId}" | \
+  jq '.metrics_parameters.enabled'
+```
+If `true`, use KRR for the right-sizing dimension: load the Phase 2b reference (`phase2b-krr-rightsizing.md`) from the SKILL.md navigation table. It produces P99-based, OOM-aware per-container recommendations from the cluster's metrics stack. The MCP/API queries below remain the source for the other dimensions (autoscaling, scheduling, cluster-level).
+
 **Via MCP (preferred):**
 ```
 "Show CPU usage across all services"

--- a/qovery-optimize/reference/phase2-optimization-dimensions.md
+++ b/qovery-optimize/reference/phase2-optimization-dimensions.md
@@ -6,6 +6,8 @@ Analyze the infrastructure across 7 dimensions. For each, calculate current cost
 
 For EACH service, compare allocated resources vs actual peak usage over the analysis period.
 
+**If Qovery observability is enabled on the cluster** (`metrics_parameters.enabled` is `true`, checked in Phase 1.3): get the measurements and recommendations from KRR instead of computing them by hand. Load the Phase 2b reference (`phase2b-krr-rightsizing.md`) from the SKILL.md navigation table. The formulas below are the fallback when observability is off or KRR cannot run; the business-context rules (seasonal peaks, minimum thresholds, growth buffers) apply in both cases.
+
 **Right-sizing formula (adjusted by business context):**
 
 | Context | Formula | Safety Buffer | Rationale |

--- a/qovery-optimize/reference/phase2b-krr-rightsizing.md
+++ b/qovery-optimize/reference/phase2b-krr-rightsizing.md
@@ -1,0 +1,68 @@
+# Phase 2b: KRR-Based Right-Sizing (when Qovery observability is enabled)
+
+Qovery integrates [KRR (Kubernetes Resource Recommender)](https://github.com/robusta-dev/krr) as a built-in, read-only **cluster analysis**: the engine runs KRR server-side against the cluster's metrics stack and streams back per-container CPU/memory recommendations (P99 percentiles, max usage, OOMKill history). When the cluster has Qovery observability enabled, prefer this over the hand-computed formulas of Dimension 1: it is OOM-aware, battle-tested, and requires no kubeconfig, no port-forward, and no local KRR install.
+
+This phase only replaces the **measurement** step of Dimension 1. The business-context guardrails of Phase 2 still apply on top of KRR's output.
+
+## 2b.1 Preconditions
+
+1. **Observability enabled on the cluster** (gives the analysis a metrics store to query):
+   ```bash
+   curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+     -H "User-Agent: QoverySkill/qovery-optimize (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+     "https://api.qovery.com/organization/{organizationId}/cluster/{clusterId}" | \
+     jq '.metrics_parameters.enabled'
+   ```
+   - `true` → run the analysis as-is.
+   - `false`/`null` but the user operates their own Prometheus on the cluster → pass it with `--prometheus-url`.
+   - Neither → skip this phase and use the Dimension 1 formulas with the metrics API.
+2. **Recent Qovery CLI.** Verify with `qovery cluster analysis --help`; if the command is missing, upgrade the CLI first.
+
+## 2b.2 Run the cost recommendation analysis
+
+```bash
+qovery cluster analysis cost-recommendation \
+  -c {clusterId} \
+  --output csv \
+  --cmd-arg=--history_duration --cmd-arg=336 \
+  --cmd-arg=--timeframe_duration --cmd-arg={days} \
+  --cmd-arg=--cpu-request --cmd-arg=99 \
+  --cmd-arg=--cpu-limit --cmd-arg=99 \
+  --cmd-arg=--memory-buffer-percentage --cmd-arg=15 \
+  --cmd-arg=--use-oomkill-data \
+  --cmd-arg=--oom-memory-buffer-percentage --cmd-arg=25 \
+  --cmd-arg=--allow-hpa
+```
+
+How it behaves:
+- The analysis is **read-only** and runs on Qovery's side; nothing is changed on the cluster.
+- `--watch` is on by default: the CLI polls until the analysis reaches SUCCEEDED/FAILED/TERMINATED, then prints the report. With `--watch=false`, fetch it later:
+  ```bash
+  qovery cluster analysis logs --cluster-id {clusterId} --analysis-id {analysisId}
+  ```
+- `--output`: `csv` for the report pipeline below, `table` for a quick human read, `json` for programmatic parsing.
+- `--cmd-arg` values are **allowlisted KRR arguments**: the engine validates them and rejects unsupported or unsafe flags, so stick to the set above.
+
+Flag rationale (the set proven on Qovery clusters):
+- P99 for CPU requests/limits, 15% memory buffer, plus a 25% buffer on containers with OOMKill history (`--use-oomkill-data`).
+- `--allow-hpa` respects HPA min replicas when computing pod-level diffs.
+- `--timeframe_duration {days}`: match the Phase 1 analysis period (7 by default, 30 for seasonal businesses). If the metrics retention is shorter than the requested window, shorten it and note the limitation in the report.
+
+## 2b.3 Map results to Qovery services
+
+KRR rows are keyed by namespace/workload/container. Map them back to Qovery objects for the report: Qovery-managed namespaces carry the environment and workloads carry the service (`qovery.com/environment-id` and `qovery.com/service-id` labels). Resolve names through the API (list environments on the cluster, then services per environment) so every row lands on the right service and its current request settings.
+
+## 2b.4 Apply the Phase 2 guardrails on top
+
+KRR output is the measurement, not the final recommendation:
+
+- Never recommend below the minimum thresholds (CPU 50m, memory 128MB).
+- Seasonal business: if the timeframe does not cover the last peak, do not right-size below that peak (Dimension 1 rule).
+- Production with expected growth: keep the growth buffer from the business context on top of KRR's number.
+- Translate to Qovery service settings (CPU in millicores, memory in MB via `PUT /application/{appId}`), applied only after user confirmation per Phase 4.
+
+In the Phase 3 report, tag these rows with source `KRR (P99, OOM-aware, {days}d)` so they are distinguishable from formula-based estimates. For a shareable client-facing HTML version, the CSV output can be dropped into the [KRR Report Generator](https://github.com/Qovery/krr-report-generator).
+
+## 2b.5 Fallback
+
+Analysis fails or preconditions unmet (no observability, no Prometheus, CLI too old and not upgradable) → fall back to Dimension 1 formulas using `GET /cluster/{clusterId}/metrics`, and record in the report that recommendations are formula-based rather than KRR-based.


### PR DESCRIPTION
## Why

qovery-optimize right-sizes services by hand: PromQL queries against the metrics API, then peak-times-buffer formulas. Qovery now ships a first-class KRR integration ('qovery cluster analysis cost-recommendation', engine-side), which produces better numbers than the formulas: P99 percentiles, max-based limits, and OOMKill history so a container that already OOMKilled never gets under-provisioned. The skill did not use it. This PR makes KRR the right-sizing source whenever the cluster has Qovery observability enabled, with the formulas kept as fallback.

## What

- New reference 'phase2b-krr-rightsizing.md': precondition check ('metrics_parameters.enabled' on the cluster), the analysis command with the Qovery-proven flag set (P99 CPU request/limit, 15% memory buffer, OOMKill-aware with 25% extra, --allow-hpa, timeframe matched to the Phase 1 analysis period), report retrieval ('qovery cluster analysis logs'), mapping rows back to Qovery services, and the fallback path.
- Phase 1.3 now checks observability first and routes right-sizing to Phase 2b when enabled; the metrics API queries remain the source for the other dimensions.
- Phase 2 Dimension 1 states the formulas are the fallback; the business-context guardrails (minimum thresholds, seasonal peaks, growth buffers) apply to both paths.
- SKILL.md: description mentions KRR (so 'run KRR' prompts route here), Phase 2b navigation row, analysis commands in the CLI quick reference, KRR link.
- New eval scenario covering the observability-enabled path.

## Design choices

- **CLI analysis, not a local KRR run.** The engine runs KRR server-side against the cluster's metrics stack: read-only, no kubeconfig, no port-forward, no local install, and '--cmd-arg' values are allowlisted and validated by the engine. A hand-run KRR would need all of that plus tunnel handling.
- **KRR replaces the measurement, not the judgment.** Guardrails stay on top: never below 50m/128MB, never below a seasonal peak the timeframe missed, growth buffers preserved, changes applied only after per-service confirmation (Phase 4 unchanged).
- **Explicit fallback.** Observability off with no user Prometheus, or CLI too old: the skill falls back to the existing Dimension 1 formulas and tags report rows as formula-based instead of KRR-based, so reports always state their source.

## Test plan

- [x] SKILL.md at 173 lines (under 500)
- [x] All internal reference links resolve
- [x] No anti-patterns (2nd-person openers, time-sensitive content, AI trailers)
- [x] evals/qovery-optimize.json valid, existing scenarios untouched (style-preserving edit, no reformat)
- [x] curl example in the new reference carries the User-Agent header per CLAUDE.md
- [x] CLI flags cross-checked against qovery-cli source (cluster_analysis*.go): command names, --cmd-arg format, --watch/--output/--no-logs behavior

## Reviewer notes

- The flag set mirrors the one documented in the internal KRR report workflow (P99 + OOM buffers); the CSV output can still be dropped into the KRR Report Generator for a client-facing HTML report.
- The reference avoids naming exact REST paths for the analysis API (CLI is the documented interface); if you prefer the raw endpoints documented too, say so and I'll add them.