### PR TITLE
feat(policy-token): add qovery-policy-token skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ AI agent skills for deploying and troubleshooting applications on Kubernetes usi
 | **qovery-speedup** | Speed up deployments — measures pipeline timeline, identifies bottlenecks (build, startup, health check, scheduling), classifies user vs Qovery responsibility, proposes Dockerfile and config fixes |
 | **qovery-preview** | Create preview environments from PRs — detects/creates blueprint environments, clones for each PR, switches branches, configures auto-shutdown (stop/delete/recycle), provides cleanup. Includes `/qovery-preview` slash command |
 | **qovery-terraform** | Generate Terraform manifests from an existing Qovery setup — reads config from API, generates HCL (qovery/qovery provider), imports resources into state, validates in test clone. Supports single or multiple environments. Safe: never applies to original without confirmation |
+| **qovery-policy-token** | Create a scoped, least-privilege API Policy Token — turns your intent into an OPA/Rego policy, tests it locally with OPA and live against the API, creates the token, and verifies it allows exactly what you want and denies everything else. Includes `/qovery-policy-token` slash command |
 
 > **Looking for Remote Development Environments (RDEs)?** RDEs are now managed directly via [rde.qovery.com](https://rde.qovery.com). See the [RDE documentation](https://www.qovery.com/docs/getting-started/quickstart/remote-dev-environments) to get started.
 
@@ -220,6 +221,13 @@ The onboard skill acts as your personal cloud architect. The deploy skill handle
 - _"Generate Terraform from my existing project"_
 - `/qovery-terraform` (slash command)
 
+**Prompts that trigger qovery-policy-token:**
+- _"Create a restricted API token that can only deploy, never delete"_
+- _"I need a scoped token for an AI agent limited to the staging environment"_
+- _"Make an OPA/Rego policy token for Qovery"_
+- _"Lock a token down to one service"_
+- `/qovery-policy-token` (slash command)
+
 ## Slash Commands
 
 Each skill includes a slash command for quick invocation. Type `/` followed by the command name in your AI tool's chat:
@@ -234,6 +242,7 @@ Each skill includes a slash command for quick invocation. Type `/` followed by t
 | `/qovery-speedup` | Analyze and fix deployment bottlenecks | `/qovery-speedup` or `/qovery-speedup my-service` |
 | `/qovery-preview` | Create a preview environment for a PR | `/qovery-preview` or `/qovery-preview PR-123` |
 | `/qovery-terraform` | Generate Terraform from existing Qovery setup | `/qovery-terraform` or `/qovery-terraform https://console.qovery.com/...` |
+| `/qovery-policy-token` | Create and verify a scoped API Policy Token | `/qovery-policy-token` or `/qovery-policy-token read-only on staging, can deploy the api service` |
 
 Commands are installed automatically by the install script. They accept optional arguments (service name, environment name, Console URL) and auto-detect context from your git workspace.
 

--- a/_shared/auth.md
+++ b/_shared/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/evals/qovery-policy-token.json
+++ b/evals/qovery-policy-token.json
@@ -1,6 +1,30 @@
 [
   {
     "skills": ["qovery-policy-token"],
+    "query": "I need a policy token but I'm not sure exactly what it should allow — help me build it.",
+    "files": [],
+    "expected_behavior": [
+      "Runs the Phase 1 guided interview instead of guessing: asks purpose/principal, blast-radius scope (service/environment/project/org), the capability menu (read, deploy, clone, stop/restart, env vars, etc.), hard denials, body constraints, usability reads, and expiry",
+      "Resolves the real UUIDs for the chosen scope (MCP/CLI/API) and restates the answers as explicit ALLOW + DENY lists for the user to confirm",
+      "Assembles the policy from the Phase 2 capability building-block library (one scope predicate + one block per chosen capability, OR-ed under `default allow := false`), trimming the env_actions/service_kinds sets to only what was asked",
+      "Runs opa-preflight.sh with an allow case per capability and a deny case per named denial until green, then creates the token only after explicit confirmation",
+      "Live-verifies (deny cases -> 401, non-destructive allow reads -> 2xx, destructive allows skipped) and delivers the token once with immutability + revoke guidance"
+    ]
+  },
+  {
+    "skills": ["qovery-policy-token"],
+    "query": "Create a policy token that can clone and deploy any environment in the Lifecycle Demo project, and that's it.",
+    "files": [],
+    "expected_behavior": [
+      "Resolves the Lifecycle Demo project UUID and confirms it; recognizes the scope is the project (input.qovery_metadata.project_id), not a single environment",
+      "Authors a policy from clone-deploy-project.rego: allows POST on `[\"api\",\"environment\",<id>,\"deploy\"]` and `[\"api\",\"environment\",<id>,\"clone\"]` only when project_id matches, with count(path)==4",
+      "Builds a matrix with allow cases (clone, deploy in project) and deny cases (clone/deploy in another project, delete/stop/read in the project) and gets opa-preflight green",
+      "Notes that clone+deploy are destructive so live-verify probes only the deny cases (expect 401) and verifies the allow side statically, unless the user opts into a real clone-and-cleanup",
+      "Flags the strictness tradeoff: with no read capability, GET/list calls will return 401 — offers to add a scoped read block if the tool needs to list environments first"
+    ]
+  },
+  {
+    "skills": ["qovery-policy-token"],
     "query": "Create a Qovery API token that can only read the staging environment and nothing else.",
     "files": [],
     "expected_behavior": [

--- a/evals/qovery-policy-token.json
+++ b/evals/qovery-policy-token.json
@@ -1,0 +1,38 @@
+[
+  {
+    "skills": ["qovery-policy-token"],
+    "query": "Create a Qovery API token that can only read the staging environment and nothing else.",
+    "files": [],
+    "expected_behavior": [
+      "Resolves the real staging environment UUID via MCP list_environments (or CLI/API), never guessing it, and confirms it with the user",
+      "Authors a least-privilege Rego policy starting with `default allow := false` that allows only GET/HEAD scoped to `input.qovery_metadata.environment_id == <staging-uuid>`, with no `package` line",
+      "Builds an allow/deny test matrix and runs templates/scripts/opa-preflight.sh (opa check + opa eval) until every case is green before creating anything, including a deny case proving another environment is not readable",
+      "Creates the token with POST /organization/{organizationId}/policyApiToken only after the user confirms the policy, and captures the returned `token` without echoing or storing it in plaintext",
+      "Live-verifies with the policy token: a read of staging returns 2xx and a read of a different environment returns 401, then hands the token over once and explains it cannot be retrieved again"
+    ]
+  },
+  {
+    "skills": ["qovery-policy-token"],
+    "query": "I need a token for our deploy bot that can deploy the api service but must never be able to delete anything.",
+    "files": [],
+    "expected_behavior": [
+      "Captures intent as an explicit allow-list (deploy the api service) and deny-list (any DELETE) and resolves the api service + environment UUIDs before writing Rego",
+      "Writes a policy allowing the exact deploy path (e.g. `input.request.path == [\"api\", \"environment\", <env>, \"service\", \"deploy\"]`) and denying deletes, warning that `method != \"DELETE\"` blocks only HTTP DELETE and scoping tightly if destructive actions are exposed as POST/PUT",
+      "Runs opa-preflight.sh with a deny case that sends a DELETE against the allowed service and asserts it is denied (false), iterating until the matrix is green",
+      "Explains that policies are immutable (no edit endpoint) so the policy must be confirmed before creation; creates the token and handles 400/403/409 (400=won't compile or has package, 403=not owner/admin, 409=name exists)",
+      "Live-verifies safely: the DELETE deny case is probed for real and must return 401 (blocked at auth before execution), while the destructive deploy allow case is verified statically via OPA and NOT auto-executed unless the user opts in per action"
+    ]
+  },
+  {
+    "skills": ["qovery-policy-token"],
+    "query": "Give me a token that can only set environment variables whose names start with FEATURE_ on our web app.",
+    "files": [],
+    "expected_behavior": [
+      "Resolves the web application UUID and confirms it, then authors a body-constrained Rego policy using `startswith(input.request.body.key, \"FEATURE_\")` scoped to POST on that app's environmentVariable path",
+      "Includes both an allow case (a FEATURE_-prefixed key) and deny cases (a non-prefixed key, and the same action on a different app) in the test matrix",
+      "Runs opa-preflight.sh and confirms the FEATURE_ key is allowed while a non-FEATURE_ key and other apps are denied, before creating the token",
+      "Notes the 65,536-character policy size limit and that no `package` line may be submitted, and creates the token with an owner/admin API token",
+      "Delivers the token once, records the token id, and explains list/revoke (GET/DELETE .../policyApiToken/{id}) plus audit-log attribution as policy:<token-id>:<token-name>"
+    ]
+  }
+]

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # https://github.com/Qovery/qovery-skills
 # ============================================================
 
-SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform")
+SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform" "qovery-policy-token")
 TARBALL_URL="https://codeload.github.com/Qovery/qovery-skills/tar.gz/refs/heads/main"
 
 # Colors (if terminal supports them)
@@ -252,6 +252,7 @@ echo -e "  ${YELLOW}qovery-optimize${NC}      — Optimize costs and right-size 
 echo -e "  ${YELLOW}qovery-speedup${NC}       — Speed up deployments and builds"
 echo -e "  ${YELLOW}qovery-preview${NC}       — Create preview environments from PRs"
 echo -e "  ${YELLOW}qovery-terraform${NC}     — Terraformize existing Qovery setups"
+echo -e "  ${YELLOW}qovery-policy-token${NC}  — Create and verify scoped API policy tokens"
 echo ""
 echo -e "${BOLD}Compatible with:${NC}"
 echo "  Claude Code, OpenCode, Cursor, VS Code Copilot, Gemini CLI,"

--- a/local-install.sh
+++ b/local-install.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # https://github.com/Qovery/qovery-skills
 # ============================================================
 
-SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform")
+SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform" "qovery-policy-token")
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Colors (if terminal supports them)
@@ -275,6 +275,7 @@ echo -e "  ${YELLOW}qovery-optimize${NC}      — Optimize costs and right-size 
 echo -e "  ${YELLOW}qovery-speedup${NC}       — Speed up deployments and builds"
 echo -e "  ${YELLOW}qovery-preview${NC}       — Create preview environments from PRs"
 echo -e "  ${YELLOW}qovery-terraform${NC}     — Terraformize existing Qovery setups"
+echo -e "  ${YELLOW}qovery-policy-token${NC}  — Create and verify scoped API policy tokens"
 echo ""
 echo -e "${BOLD}Slash commands:${NC} /qovery-<skill> (e.g. /qovery-deploy, /qovery-troubleshoot, /qovery-terraform…)."
 echo ""

--- a/qovery-deploy/reference/auth.md
+++ b/qovery-deploy/reference/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/qovery-onboard/reference/auth.md
+++ b/qovery-onboard/reference/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/qovery-optimize/reference/auth.md
+++ b/qovery-optimize/reference/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/qovery-policy-token/SKILL.md
+++ b/qovery-policy-token/SKILL.md
@@ -63,8 +63,8 @@ For a regular role-based API token (CI/CD, Terraform, broad access), this skill 
 ```
 Create & Verify a Policy Token:
 - [ ] Phase 0 — Prereqs: owner/admin API token available, resolve organizationId, check for OPA CLI
-- [ ] Phase 1 — Intent + IDs: capture allow-list + deny-list, resolve real resource UUIDs (MCP/CLI/API)
-- [ ] Phase 2 — Author Rego: write least-privilege policy, explain each rule, confirm with user
+- [ ] Phase 1 — Guided interview: ask purpose → scope → capabilities → denials → reads → expiry; resolve real UUIDs (MCP/CLI/API)
+- [ ] Phase 2 — Author Rego: assemble least-privilege policy from the capability library, explain each rule, confirm with user
 - [ ] Phase 3 — Local test: build allow/deny matrix, run opa-preflight.sh, iterate until all green
 - [ ] Phase 4 — Create: POST the token AFTER user confirms policy; capture id + secret without echoing
 - [ ] Phase 5 — Live verify: probe deny cases (expect 401) + safe allow reads (expect 2xx), report
@@ -101,8 +101,8 @@ Every request is evaluated against this JSON `input`. Policies branch on these f
 |---|---|---|
 | Auth | [reference/auth.md](reference/auth.md) | Token handling + secrecy rules + User-Agent header |
 | Console URL | [reference/console-url-detection.md](reference/console-url-detection.md) | Extract org/project/env/service IDs from Console URLs |
-| Phase 1 | [reference/phase1-intent-and-ids.md](reference/phase1-intent-and-ids.md) | Intent questionnaire; resolve real resource UUIDs via MCP/CLI/API |
-| Phase 2 | [reference/phase2-authoring-rego.md](reference/phase2-authoring-rego.md) | Rego patterns, documented example policies, constraints, template picker |
+| Phase 1 | [reference/phase1-intent-and-ids.md](reference/phase1-intent-and-ids.md) | **Guided interview** (purpose → scope → capabilities → denials → body constraints → reads → expiry); resolve real UUIDs via MCP/CLI/API |
+| Phase 2 | [reference/phase2-authoring-rego.md](reference/phase2-authoring-rego.md) | Rego patterns + **capability→Rego building-block library** (verified API paths) to assemble a complete policy; constraints; pitfalls |
 | Phase 3 | [reference/phase3-local-testing.md](reference/phase3-local-testing.md) | Install/check OPA, build the allow/deny matrix, run pre-flight, read results |
 | Phase 4 | [reference/phase4-create-token.md](reference/phase4-create-token.md) | Create endpoint, request/response, error handling (400/403/409), secret capture |
 | Phase 5 | [reference/phase5-live-verify.md](reference/phase5-live-verify.md) | Safe live testing (why deny is safe / allow-destructive is not), report format |
@@ -116,6 +116,7 @@ Every request is evaluated against this JSON `input`. Policies branch on these f
 | [templates/policies/deploy-only.rego](templates/policies/deploy-only.rego) | Deploy a specific service/app and nothing else |
 | [templates/policies/modify-one-service-never-delete.rego](templates/policies/modify-one-service-never-delete.rego) | Change one service, never DELETE |
 | [templates/policies/body-constrained-env-var.rego](templates/policies/body-constrained-env-var.rego) | Constrain the request body (e.g. env var keys prefixed `FEATURE_`) |
+| [templates/policies/clone-deploy-project.rego](templates/policies/clone-deploy-project.rego) | Clone + deploy any environment in one project, nothing else (project-scoped) |
 | [templates/test-matrix.example.json](templates/test-matrix.example.json) | Schema for allow/deny test cases (input document + expected result + live probe) |
 | [templates/scripts/opa-preflight.sh](templates/scripts/opa-preflight.sh) | Run `opa check` + `opa eval` per matrix case, print a pass/fail table |
 | [templates/scripts/create-policy-token.sh](templates/scripts/create-policy-token.sh) | POST create; capture id + token to env WITHOUT echoing; handle 400/403/409 |

--- a/qovery-policy-token/SKILL.md
+++ b/qovery-policy-token/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: qovery-policy-token
+description: Creates a scoped Qovery API Policy Token from a user's intent — authors a least-privilege Open Policy Agent (Rego) policy, tests it locally with OPA and live against the API, creates the token, and verifies it allows exactly what the user wants and denies everything else. Use when the user wants a restricted, least-privilege, or agent-scoped Qovery API token, an OPA/Rego policy token, or wants to lock a token down to specific environments, services, or actions.
+license: MIT
+compatibility: opencode
+metadata:
+  audience: platform-engineers
+  workflow: policy-token-provisioning
+---
+
+# Qovery Policy Token Skill
+
+Turns a plain-English intent ("a token that can read staging and deploy the API service, but never delete anything") into a working, verified Qovery **API Policy Token**. It authors the Open Policy Agent (Rego) policy, tests it locally with OPA and live against the API, creates the token, and proves it does exactly what the user expects — allowing the intended actions and denying everything else.
+
+An **API Policy Token** is a second kind of Qovery organization token whose authorization is a **Rego policy evaluated on every request** (via Open Policy Agent), instead of an RBAC role. This expresses constraints a role cannot — e.g. "read everything in one environment, deploy it, modify one service, but never delete." Internally a policy token is granted org-admin access and the policy is what narrows it, so a permissive policy is dangerous: **least privilege is the whole point.**
+
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
+
+```bash
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery-policy-token"
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
+> **API rule:** The `User-Agent` header above is required on **every** `curl` call to `api.qovery.com` — not just this tracking call. Never omit it.
+
+## CRITICAL SAFETY RULES
+
+> **Confirm the policy BEFORE creating the token.** Policies are **immutable** — there is no edit endpoint. To change a policy you must delete the token and create a new one. Get the policy green in local testing (Phase 3) and get explicit user sign-off first.
+>
+> **The created token is a secret shown ONCE.** It is returned only in the create response and can never be retrieved again. NEVER echo, print, log, or write it to a repo file. Capture it inline into an env var (see [reference/auth.md](reference/auth.md)) and hand it to the user once, referring to it as `***` everywhere else.
+>
+> **Start fail-closed.** Every policy begins with `default allow := false` and adds only the narrow rules the user asked for. Never ship `allow := true` — it grants full org-admin access.
+>
+> **Live-testing DENY cases is safe. Live-testing destructive ALLOW cases is not.** Qovery evaluates the policy at authentication time, *before* the request reaches the endpoint, so a denied request returns `401` and never executes. A denied `DELETE` is therefore safe to probe. An *allowed* mutating action (deploy, delete, update) WILL execute — never auto-run those; verify them statically with OPA and ask the user before executing any destructive allowed action.
+>
+> **Never hard-code guessed UUIDs.** Every environment/service/project/cluster ID a policy references must be resolved from the real org (MCP/CLI/API) and confirmed with the user. A typo'd UUID silently makes a rule never match.
+>
+> **Creating a policy token requires org Owner or Admin.** A non-admin caller gets `403`. Surface this early (Phase 0).
+
+## When to Use This Skill
+
+Trigger phrases:
+- "Create a restricted / scoped / least-privilege Qovery API token"
+- "I need a token an AI agent can use that can only deploy, never delete"
+- "Give me a token that can only read the staging environment"
+- "Make an OPA / Rego policy token for Qovery"
+- "Lock this token down to one service"
+- "Create a token that can only set env vars starting with FEATURE_"
+- `/qovery-policy-token` (slash command)
+
+For a regular role-based API token (CI/CD, Terraform, broad access), this skill does not apply — that is a standard API Token, managed in the Console under the same settings page.
+
+## Workflow checklist
+
+```
+Create & Verify a Policy Token:
+- [ ] Phase 0 — Prereqs: owner/admin API token available, resolve organizationId, check for OPA CLI
+- [ ] Phase 1 — Intent + IDs: capture allow-list + deny-list, resolve real resource UUIDs (MCP/CLI/API)
+- [ ] Phase 2 — Author Rego: write least-privilege policy, explain each rule, confirm with user
+- [ ] Phase 3 — Local test: build allow/deny matrix, run opa-preflight.sh, iterate until all green
+- [ ] Phase 4 — Create: POST the token AFTER user confirms policy; capture id + secret without echoing
+- [ ] Phase 5 — Live verify: probe deny cases (expect 401) + safe allow reads (expect 2xx), report
+- [ ] Phase 6 — Deliver: hand over token once, explain immutability, list/revoke, audit attribution
+```
+
+## The Rego input document (what a policy sees)
+
+Every request is evaluated against this JSON `input`. Policies branch on these fields — know them before authoring.
+
+| Field | Meaning |
+|---|---|
+| `input.request.method` | HTTP verb, uppercase (`GET`, `POST`, `DELETE`, …) |
+| `input.request.path` | Decoded path segments as an array, e.g. `["api","environment","<uuid>","service","deploy"]` |
+| `input.request.body` | Parsed JSON body, or `null` when the request has none |
+| `input.qovery_metadata.organization_id` | Organization the token belongs to |
+| `input.qovery_metadata.service_id` | Targeted service UUID, or `null` |
+| `input.qovery_metadata.service_type` | `APPLICATION`, `CONTAINER`, `DATABASE`, `ROUTER`, `JOB`, `HELM`, `TERRAFORM`, `ARGOCD_APP`, `AGENTIC_WORKFLOW`, or `null` |
+| `input.qovery_metadata.environment_id` | Targeted environment UUID, or `null` |
+| `input.qovery_metadata.project_id` | Targeted project UUID, or `null` |
+| `input.qovery_metadata.cluster_id` | Cluster the targeted resource runs on, or `null` |
+| `input.token.id` / `input.token.name` | The token making the request |
+
+**Rules of the language** (OPA 1.19, rego v1 — `if`, `in`, `contains` need no imports):
+- The policy MUST define `allow`. The request is permitted only when `allow` evaluates to boolean `true`. Anything else — no matching rule, non-boolean, undefined — **denies** (`401`). Fail-closed by default.
+- A rule body is AND; multiple rules with the same name are OR.
+- Missing input fields are *undefined*, not errors — expressions using them simply don't fire (this is what makes fail-closed natural).
+- **No `package` line** — Qovery injects a per-token package; submitting one returns `400`.
+- Max policy size: **65,536 characters**.
+
+## Reference materials (load on demand)
+
+| Phase | File | Purpose |
+|---|---|---|
+| Auth | [reference/auth.md](reference/auth.md) | Token handling + secrecy rules + User-Agent header |
+| Console URL | [reference/console-url-detection.md](reference/console-url-detection.md) | Extract org/project/env/service IDs from Console URLs |
+| Phase 1 | [reference/phase1-intent-and-ids.md](reference/phase1-intent-and-ids.md) | Intent questionnaire; resolve real resource UUIDs via MCP/CLI/API |
+| Phase 2 | [reference/phase2-authoring-rego.md](reference/phase2-authoring-rego.md) | Rego patterns, documented example policies, constraints, template picker |
+| Phase 3 | [reference/phase3-local-testing.md](reference/phase3-local-testing.md) | Install/check OPA, build the allow/deny matrix, run pre-flight, read results |
+| Phase 4 | [reference/phase4-create-token.md](reference/phase4-create-token.md) | Create endpoint, request/response, error handling (400/403/409), secret capture |
+| Phase 5 | [reference/phase5-live-verify.md](reference/phase5-live-verify.md) | Safe live testing (why deny is safe / allow-destructive is not), report format |
+| Phase 6 | [reference/phase6-lifecycle.md](reference/phase6-lifecycle.md) | Deliver once, immutability, list/revoke, audit-log attribution |
+
+## Templates
+
+| Template | Use |
+|---|---|
+| [templates/policies/read-only-env.rego](templates/policies/read-only-env.rego) | Read-only (GET/HEAD) on one environment |
+| [templates/policies/deploy-only.rego](templates/policies/deploy-only.rego) | Deploy a specific service/app and nothing else |
+| [templates/policies/modify-one-service-never-delete.rego](templates/policies/modify-one-service-never-delete.rego) | Change one service, never DELETE |
+| [templates/policies/body-constrained-env-var.rego](templates/policies/body-constrained-env-var.rego) | Constrain the request body (e.g. env var keys prefixed `FEATURE_`) |
+| [templates/test-matrix.example.json](templates/test-matrix.example.json) | Schema for allow/deny test cases (input document + expected result + live probe) |
+| [templates/scripts/opa-preflight.sh](templates/scripts/opa-preflight.sh) | Run `opa check` + `opa eval` per matrix case, print a pass/fail table |
+| [templates/scripts/create-policy-token.sh](templates/scripts/create-policy-token.sh) | POST create; capture id + token to env WITHOUT echoing; handle 400/403/409 |
+| [templates/scripts/live-verify.sh](templates/scripts/live-verify.sh) | Curl each case with the token, compare status; refuse destructive allow-probes |
+
+## MCP Server, CLI, API — priority order
+
+Prefer the **Qovery MCP Server** (`https://mcp.qovery.com/mcp`) for resolving IDs (org → project → environment → service) — it authenticates internally, so no token flows through the shell. Check availability by calling `list_organizations`; if present, use `list_projects` / `list_environments` / `list_services` to resolve the UUIDs a policy needs. Fall back to the `qovery` CLI, then to the REST API via `curl`. The **create/list/delete of policy tokens themselves have no MCP tool** — they go through the REST API with an owner/admin token (see Phase 4).
+
+## Quick reference
+
+```bash
+# Prereqs
+opa version                          # OPA 1.19 recommended for local testing (best-effort)
+jq --version                         # required for parsing API responses
+test -n "${QOVERY_API_TOKEN:-}" && echo "admin token present" || echo "need owner/admin token"
+
+# Resolve organization id
+QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  "https://api.qovery.com/organization" | jq -r '.results[0].id')
+
+# Local pre-flight (Phase 3): policy + test matrix -> pass/fail table
+bash templates/scripts/opa-preflight.sh policy.rego test-matrix.json
+
+# Create the token (Phase 4) — only after the policy is confirmed
+bash templates/scripts/create-policy-token.sh "$QOVERY_ORG_ID" "deploy-agent" policy.rego
+
+# Live verify (Phase 5) — deny cases + safe allow reads
+bash templates/scripts/live-verify.sh test-matrix.json
+
+# List / revoke (Phase 6)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  "https://api.qovery.com/organization/${QOVERY_ORG_ID}/policyApiToken" | jq '.results[] | {id, name}'
+# DELETE .../policyApiToken/{policyApiTokenId} to revoke (immediate)
+```
+
+## Policy token API endpoints
+
+All under `https://api.qovery.com`, authenticated with a regular **owner/admin** API token.
+
+| Operation | Method + Path | Notes |
+|---|---|---|
+| Create | `POST /organization/{organizationId}/policyApiToken` | Body `{name, description?, opa_policy, expires_at?}` → response includes `id` and the one-time `token`. Errors: `400` (empty/oversized/has `package`/won't compile), `403` (not owner/admin), `409` (name exists) |
+| List | `GET /organization/{organizationId}/policyApiToken` | Returns each token's `opa_policy` — never the token value |
+| Revoke | `DELETE /organization/{organizationId}/policyApiToken/{policyApiTokenId}` | Immediate; no caching. Also the only way to "change" a policy: delete + recreate |
+
+There is **no** update endpoint (policies are immutable) and **no** server-side simulate endpoint (testing is local OPA + live probing).
+
+## Reference links
+
+- **API Policy Token (Beta) guide**: <https://www.qovery.com/docs/configuration/organization/api-policy-token>
+- **Create endpoint**: <https://www.qovery.com/docs/api-reference/organization-policy-api-token/create-an-organization-policy-api-token>
+- **Open Policy Agent / Rego**: <https://www.openpolicyagent.org/docs/latest/policy-language/>
+- **Qovery API**: <https://www.qovery.com/docs/api-reference/introduction>
+- **Qovery MCP Server**: <https://mcp.qovery.com/mcp>
+- **Qovery Console**: <https://console.qovery.com>

--- a/qovery-policy-token/commands/qovery-policy-token.md
+++ b/qovery-policy-token/commands/qovery-policy-token.md
@@ -1,0 +1,17 @@
+---
+description: Create and verify a scoped Qovery API Policy Token from your intent
+---
+
+Create a least-privilege Qovery API Policy Token (OPA/Rego) that allows exactly what you want and denies everything else.
+
+If arguments are provided, use them as context:
+- `$ARGUMENTS` — a plain-English intent ("read-only on staging, can deploy the api service, never delete"), a Qovery Console URL, or environment/service names to scope the policy to
+
+Follow the qovery-policy-token skill to:
+1. Capture the intent as an explicit allow-list + deny-list and resolve the real resource UUIDs
+2. Author a least-privilege Rego policy and explain each rule
+3. Test the policy locally with OPA against an allow/deny matrix until it is green
+4. Create the token via the API (only after you confirm the policy — policies are immutable)
+5. Verify the live token allows the intended actions and denies everything else, then hand it over once
+
+CRITICAL: Confirm the policy before creating the token (policies cannot be edited), and never echo, print, or store the returned token value.

--- a/qovery-policy-token/reference/auth.md
+++ b/qovery-policy-token/reference/auth.md
@@ -1,0 +1,92 @@
+# Qovery Authentication
+
+## Security — Token Handling Rules
+
+**CRITICAL: NEVER display, log, print, or capture Qovery token values.**
+
+- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+  ```bash
+  # CORRECT — token is inline, never shown:
+  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+
+  # WRONG — token value would appear in output:
+  qovery auth token --print
+  echo $(qovery auth token --print)
+  export TOKEN=$(qovery auth token --print)
+  ```
+- NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
+- NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
+- NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
+- NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
+- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
+- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+
+## Qovery API Request Rules — User-Agent
+
+**Every `curl` request to the Qovery API (`api.qovery.com`) MUST include a User-Agent header identifying the skill and version.**
+
+The version is read from `_version.txt` (written at install time by `install.sh`). When executing curl commands, the agent MUST add this header:
+
+```bash
+# Read the version (do this once per session):
+QOVERY_SKILLS_VERSION=$(cat _version.txt 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+# Add to every curl command:
+-H "User-Agent: QoverySkill/auth (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)"
+```
+
+Full example:
+```bash
+curl -s \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/auth (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  https://api.qovery.com/organization
+```
+
+This applies to ALL curl commands targeting `api.qovery.com` — even when reference file examples don't explicitly show the User-Agent header. The agent MUST add it to every request it executes. Use `auth` as the context for the shared auth flow. When executing curl commands from a specific skill's reference files, use that skill's name instead (e.g., `qovery-deploy`, `qovery-troubleshoot`).
+
+---
+
+## 1. Existing API token in environment
+
+```bash
+# Check if a token is available (without printing it):
+test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
+```
+
+If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
+
+## 2. CLI already authenticated (`qovery auth token`)
+
+```bash
+# Check if the CLI is authenticated (without printing the token):
+qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+```
+
+If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+
+```bash
+# Token flows through the shell but is never visible to the agent:
+curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+```
+
+Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+
+```bash
+# Create the token and store it directly in .env (not displayed):
+qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
+# The user should manually export it or add it to their secure env config
+echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+```
+
+## 3. Interactive login
+
+If neither of the above works, prompt the user:
+
+```bash
+qovery auth                      # interactive browser login
+# OR for headless:
+# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+```
+
+After login, fall through to step 2 to obtain a token.

--- a/qovery-policy-token/reference/auth.md
+++ b/qovery-policy-token/reference/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/qovery-policy-token/reference/console-url-detection.md
+++ b/qovery-policy-token/reference/console-url-detection.md
@@ -1,0 +1,58 @@
+# Qovery Console URL Detection
+
+When the user provides a Qovery Console URL (from `console.qovery.com` or
+`new-console.qovery.com`), extract the resource IDs directly from the URL path.
+This saves significant back-and-forth — no need to ask which organization,
+project, environment, or service the user means.
+
+## URL format
+
+```
+https://{console.qovery.com|new-console.qovery.com}/organization/{orgId}/project/{projectId}/environment/{envId}/service/{serviceId}[/{page}]
+```
+
+## Extraction rules
+
+- `orgId` — UUID after `/organization/`
+- `projectId` — UUID after `/project/`
+- `envId` — UUID after `/environment/`
+- `serviceId` — UUID after `/service/`
+- `page` — optional suffix (`service-logs`, `deployment-logs`, `general`, `variables`, `settings`, etc.) gives context about what the user is viewing
+
+Not every URL contains all segments. Use whatever IDs are present:
+
+- URL with only `orgId` → organization is known, still ask about project/environment/service
+- URL with `orgId` + `projectId` + `envId` → environment is known, may still need service selection
+- URL with all four IDs → fully resolved, proceed directly
+
+## Resolving names from IDs
+
+After extracting IDs, resolve names via the API to confirm with the user:
+
+```bash
+# Organization name
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/organization" | jq '.results[] | select(.id == "{orgId}") | {id, name}'
+
+# Project name
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/project/{projectId}" | jq '{id, name}'
+
+# Environment name + all service names/statuses in one call
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}/statuses" | jq '{
+    environment: .environment.state,
+    applications: [.applications[] | {id, name: .name, state}],
+    containers: [.containers[] | {id, name: .name, state}],
+    databases: [.databases[] | {id, name: .name, state}],
+    jobs: [.jobs[] | {id, name: .name, state}],
+    helms: [.helms[] | {id, name: .name, state}]
+  }'
+
+# Cluster ID from the environment (the environment knows its cluster)
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  "https://api.qovery.com/environment/{envId}" | jq '{cluster_id: .cluster_id}'
+```
+
+Use the extracted IDs directly in all subsequent API calls and skip any
+discovery questions for resources already identified by the URL.

--- a/qovery-policy-token/reference/phase1-intent-and-ids.md
+++ b/qovery-policy-token/reference/phase1-intent-and-ids.md
@@ -60,7 +60,10 @@ qovery service list --environment "<env-id>"         # service ids + types
 ```bash
 curl -s "https://api.qovery.com/organization/{organizationId}/project" | jq '.results[] | {id, name}'
 curl -s "https://api.qovery.com/project/{projectId}/environment"        | jq '.results[] | {id, name}'
-curl -s "https://api.qovery.com/environment/{environmentId}/service"    | jq '.results[] | {id, name, service_type}'
+# Services are listed per type — there is no /environment/{id}/service endpoint (it 404s):
+for t in application container database job helm; do
+  curl -s "https://api.qovery.com/environment/{environmentId}/$t" | jq --arg t "$t" '.results[]? | {id, name, service_type: $t}'
+done
 ```
 
 If the user gave a **Console URL**, extract IDs from it first (see `console-url-detection.md`) and confirm the names match what they intend.

--- a/qovery-policy-token/reference/phase1-intent-and-ids.md
+++ b/qovery-policy-token/reference/phase1-intent-and-ids.md
@@ -8,29 +8,57 @@ The policy is only as good as the intent behind it. This phase turns a vague ask
 - **organizationId.** Resolve it (MCP `list_organizations`, or `GET /organization` → `.results[0].id`). Confirm with the user if they belong to more than one org.
 - **OPA CLI** (`opa version`) for local testing — best-effort; see `phase3-local-testing.md` if missing.
 
-## 1.2 Elicit the intent
+## 1.2 Guided interview — build the intent with the user
 
-Ask the user, concretely:
+**Do not guess the policy.** Walk the user through the interview below, asking one topic at a time and offering concrete menus (use your interactive question UI if you have one). Each answer maps directly to a Rego building block in [phase2-authoring-rego.md](phase2-authoring-rego.md) §2.3b. Skip a step only when the user has already answered it.
 
-1. **Who/what will use the token?** (an AI agent, a CI job, a partner script) — this sets how tight it must be.
-2. **What must it be able to do?** Verbs + targets: "read", "deploy", "restart", "set env vars", "scale". For each, *which* resource.
-3. **What must it NEVER do?** Especially "never delete", "never touch production", "never read secrets".
-4. **Scope boundaries.** One environment? One project? One service? A whole org (rarely appropriate)?
-5. **Expiry?** Optional `expires_at` (RFC 3339). Recommend one for agent tokens.
+**Step A — Purpose & principal.** "Who or what will use this token?" — an AI agent, a CI/CD pipeline, a teammate, an external partner, a one-off script. This sets how tight to be and whether to recommend an expiry (Step G). Agent/partner tokens should be the tightest.
 
-Restate the answer as two explicit lists before writing any Rego:
+**Step B — Blast radius (scope).** "What is the widest boundary this token may ever act within?" Offer:
+- **one service** → scope rules on `input.qovery_metadata.service_id`
+- **one environment** → scope on `environment_id`
+- **one project** (any environment/service under it) → scope on `project_id`
+- **whole organization** → no resource scope (rare; flag it as broad and confirm twice)
+
+Resolve the chosen boundary's real UUID(s) in §1.3. Everything the token can do will be *and*-ed with this scope.
+
+**Step C — Capabilities (the allow-list).** "Which actions should it be able to perform?" Present this menu and let the user pick as many as apply — each maps to a building block in §2.3b:
+- Read / observe (GET) — dashboards, logs, config, statuses
+- Deploy / redeploy environments
+- Clone environments
+- Stop / restart environments
+- Cancel a running deployment
+- Deploy a specific service (application / container / job / database / helm)
+- Manage environment variables (optionally constrained — Step E)
+- Scale or update resources (CPU/RAM/instances)
+- Create new services
+- Delete resources
+
+For each picked capability, confirm the granularity: does it apply to the *whole scope* from Step B, or only to one named resource inside it?
+
+**Step D — Hard denials (safety double-check).** "Is there anything it must NEVER do, even by accident?" e.g. never delete, never touch production, never read secrets, never modify another project. With `default allow := false` these are already denied unless a capability in Step C grants them — but naming them explicitly turns each into a **deny test case** (Phase 3) that proves the boundary holds. Always capture at least one.
+
+**Step E — Value/body constraints (optional).** If a capability touches request bodies (e.g. creating env vars), ask for limits: "only keys starting with `FEATURE_`", "only these allowed values", etc. Maps to the body-constraint block in §2.3b.
+
+**Step F — Usability reads.** Many actions need a preceding read (a CLI/Console lists environments before cloning; a deploy tool reads status). Ask: "Does the tool need to list or read resources in this scope to function?" If yes and Step C didn't already include reads, add a **scoped GET** block so the token isn't so strict it can't be used. If the user truly wants *only* the write verbs, note that reads will return `401`.
+
+**Step G — Expiry.** "Should the token expire?" Optional `expires_at` (RFC 3339). Recommend one for agent, CI, and partner tokens.
+
+Then **restate the answers as two explicit lists** and get agreement before writing Rego:
 
 ```
+SCOPE: project <proj-uuid> (Lifecycle Demo)
 ALLOW:
-  - GET/HEAD anything in environment <env-uuid> (read-only staging)
-  - POST deploy service <svc-uuid>
-DENY (must be blocked):
-  - any DELETE anywhere
-  - any write to environment <prod-env-uuid>
-  - reading/writing any other environment
+  - POST clone any environment in the project
+  - POST deploy any environment in the project
+DENY (must be blocked — becomes test cases):
+  - any DELETE in the project
+  - clone/deploy in any OTHER project
+  - any GET/read (token is write-only by request)
+EXPIRES: none
 ```
 
-If the user's ask is broad ("a token for our agent to manage staging"), narrow it with follow-ups — a policy that allows more than needed defeats the purpose. When in doubt, start smaller; adding a rule later means delete + recreate, but that is safer than over-granting.
+If the ask is broad ("a token to manage staging"), narrow it with follow-ups — a policy that allows more than needed defeats the purpose. When in doubt start smaller: adding a capability later means delete + recreate, which is safer than over-granting.
 
 ## 1.3 Resolve the real UUIDs (never guess)
 

--- a/qovery-policy-token/reference/phase1-intent-and-ids.md
+++ b/qovery-policy-token/reference/phase1-intent-and-ids.md
@@ -1,0 +1,76 @@
+# Phase 1 — Capture Intent and Resolve Resource IDs
+
+The policy is only as good as the intent behind it. This phase turns a vague ask into an explicit **allow-list + deny-list**, and resolves every UUID the policy will hard-reference. That allow/deny list becomes the test matrix used in Phase 3 and Phase 5 — write it down precisely.
+
+## 1.1 Confirm prerequisites (Phase 0 carryover)
+
+- **Owner/admin token.** Creating a policy token requires org Owner or Admin. If `POST .../policyApiToken` later returns `403`, the caller isn't an admin — surface this now, not after authoring a policy.
+- **organizationId.** Resolve it (MCP `list_organizations`, or `GET /organization` → `.results[0].id`). Confirm with the user if they belong to more than one org.
+- **OPA CLI** (`opa version`) for local testing — best-effort; see `phase3-local-testing.md` if missing.
+
+## 1.2 Elicit the intent
+
+Ask the user, concretely:
+
+1. **Who/what will use the token?** (an AI agent, a CI job, a partner script) — this sets how tight it must be.
+2. **What must it be able to do?** Verbs + targets: "read", "deploy", "restart", "set env vars", "scale". For each, *which* resource.
+3. **What must it NEVER do?** Especially "never delete", "never touch production", "never read secrets".
+4. **Scope boundaries.** One environment? One project? One service? A whole org (rarely appropriate)?
+5. **Expiry?** Optional `expires_at` (RFC 3339). Recommend one for agent tokens.
+
+Restate the answer as two explicit lists before writing any Rego:
+
+```
+ALLOW:
+  - GET/HEAD anything in environment <env-uuid> (read-only staging)
+  - POST deploy service <svc-uuid>
+DENY (must be blocked):
+  - any DELETE anywhere
+  - any write to environment <prod-env-uuid>
+  - reading/writing any other environment
+```
+
+If the user's ask is broad ("a token for our agent to manage staging"), narrow it with follow-ups — a policy that allows more than needed defeats the purpose. When in doubt, start smaller; adding a rule later means delete + recreate, but that is safer than over-granting.
+
+## 1.3 Resolve the real UUIDs (never guess)
+
+Every `environment_id`, `service_id`, `project_id`, or `cluster_id` a rule references must be a real UUID from this org. A wrong or invented UUID makes the rule silently never fire (fail-closed) — the token then does *less* than intended, or nothing.
+
+**Priority order: MCP → CLI → API.**
+
+**MCP Server** (preferred — no token in the shell). Check availability with `list_organizations`; then chain top-down:
+
+| Tool | Params | Resolves |
+|---|---|---|
+| `list_organizations` | — | organization_id |
+| `list_projects` | `organization_id` | project_id |
+| `list_environments` | `project_id` | environment_id |
+| `list_services` | `environment_id` | service_id (+ service_type) for every app/container/job/db/helm |
+
+**CLI fallback:**
+
+```bash
+qovery project list                                  # project ids
+qovery environment list --project "<project-id>"     # environment ids
+qovery service list --environment "<env-id>"         # service ids + types
+```
+
+**API fallback** (add the standard `Authorization: Token` + `User-Agent` headers — see `auth.md`):
+
+```bash
+curl -s "https://api.qovery.com/organization/{organizationId}/project" | jq '.results[] | {id, name}'
+curl -s "https://api.qovery.com/project/{projectId}/environment"        | jq '.results[] | {id, name}'
+curl -s "https://api.qovery.com/environment/{environmentId}/service"    | jq '.results[] | {id, name, service_type}'
+```
+
+If the user gave a **Console URL**, extract IDs from it first (see `console-url-detection.md`) and confirm the names match what they intend.
+
+## 1.4 Confirm before authoring
+
+Show the user the resolved mapping — name → UUID — and the allow/deny lists, and get explicit agreement. Because the policy will be immutable once the token is created, this confirmation is the cheapest place to catch a wrong environment or an over-broad rule.
+
+Output of this phase, carried into Phase 2 and Phase 3:
+- `organizationId`
+- the confirmed allow-list and deny-list
+- a name → UUID table for every resource a rule will reference
+- optional `expires_at`

--- a/qovery-policy-token/reference/phase2-authoring-rego.md
+++ b/qovery-policy-token/reference/phase2-authoring-rego.md
@@ -1,0 +1,107 @@
+# Phase 2 — Author the Rego Policy
+
+Translate the Phase 1 allow-list into the smallest Rego policy that permits exactly those requests and denies the rest. Present it to the user with a plain-English explanation of every rule, and get sign-off before Phase 4 (the policy is immutable after creation).
+
+## 2.1 The shape of every policy
+
+```rego
+default allow := false        # fail-closed: deny unless a rule below says otherwise
+
+allow if <rule_1>
+allow if <rule_2>
+```
+
+- Start with `default allow := false`. Never write `allow := true` unconditionally — a policy token is org-admin narrowed only by its policy, so that grants full access.
+- Each `allow if { ... }` body is **AND**. Multiple `allow` rules are **OR**.
+- **No `package` line** — Qovery adds one per token; including one returns `400`.
+- Keep it ≤ 65,536 characters.
+- OPA 1.19 / rego v1: `if`, `in`, `contains`, and stdlib (`startswith`, `endswith`, `count`, `regex.match`, `sprintf`) are available without imports.
+
+## 2.2 What to branch on
+
+Match against the input document (full field list in SKILL.md):
+
+- **By method** — `input.request.method in {"GET", "HEAD"}` for read-only; `!= "DELETE"` to forbid deletes.
+- **By targeted resource** — `input.qovery_metadata.environment_id == "<env-uuid>"`, `...service_id == "<svc-uuid>"`, `...project_id`, `...cluster_id`. These are resolved by Qovery from the path, so they work regardless of the exact route.
+- **By exact path** — `input.request.path == ["api","environment","<env-uuid>","service","deploy"]` for a specific action. The policy sees the raw decoded path segments, not a route template.
+- **By body** — `startswith(input.request.body.key, "FEATURE_")` to constrain payloads.
+- **By service type** — `input.qovery_metadata.service_type == "DATABASE"`.
+
+Prefer `qovery_metadata` scoping (environment_id/service_id) over hand-matching `request.path` when you want "anything targeting this resource" — it is more robust than enumerating every route. Use exact `request.path` when you want to allow one specific action (like deploy) and nothing else.
+
+## 2.3 Documented patterns (copy from templates/, then adapt)
+
+Pick the closest starter under `templates/policies/` and substitute the confirmed UUIDs. These mirror the official docs.
+
+**Read-only access to one environment** — `templates/policies/read-only-env.rego`:
+
+```rego
+default allow := false
+
+allowed_environment_id := "<ENV_UUID>"
+
+allow if {
+	input.request.method in {"GET", "HEAD"}
+	input.qovery_metadata.environment_id == allowed_environment_id
+}
+```
+
+**Deploy, and nothing else** — `templates/policies/deploy-only.rego`:
+
+```rego
+default allow := false
+
+allowed_environment_id := "<ENV_UUID>"
+allowed_application_id := "<APP_UUID>"
+
+allow if input.request.path == ["api", "environment", allowed_environment_id, "service", "deploy"]
+allow if input.request.path == ["api", "application", allowed_application_id, "deploy"]
+```
+
+**Change one service, never delete** — `templates/policies/modify-one-service-never-delete.rego`:
+
+```rego
+default allow := false
+
+allowed_application_id := "<APP_UUID>"
+
+allow if {
+	input.request.method != "DELETE"
+	input.qovery_metadata.service_id == allowed_application_id
+}
+```
+
+**Constrain the request body** — `templates/policies/body-constrained-env-var.rego`:
+
+```rego
+default allow := false
+
+allowed_application_id := "<APP_UUID>"
+
+allow if {
+	input.request.method == "POST"
+	input.request.path == ["api", "application", allowed_application_id, "environmentVariable"]
+	startswith(input.request.body.key, "FEATURE_")
+}
+```
+
+Combine rules with multiple `allow if` blocks (OR) to build "read this env AND deploy this service AND modify that service but never delete" — see the composite starter policy in the API Policy Token docs.
+
+## 2.4 Common pitfalls
+
+- **Over-broad reads.** `method == "GET"` with no resource scope lets the token read the *entire org*. Always pair a method check with an environment/service scope unless org-wide read is truly intended.
+- **DELETE hiding in a different verb.** Some destructive actions are `POST` (e.g. a deploy). "Never delete" (`method != "DELETE"`) does not block a destructive `POST`. If the user means "never change production", scope by environment, not just method.
+- **Guessed UUIDs.** A wrong UUID never matches — the rule silently does nothing. Use only the Phase 1 confirmed IDs.
+- **`package` line.** Do not add one to `opa_policy`. (The local test harness adds a temporary one only for `opa eval`; the submitted policy must not have it — the harness strips/omits it on create.)
+
+## 2.5 Present and confirm
+
+Show the final policy plus a one-line explanation per rule, e.g.:
+
+```
+Rule 1 (read_only): allows GET/HEAD on environment staging (<uuid>) — read dashboards, logs, config
+Rule 2 (deploy):    allows POST .../service/deploy on staging — trigger a deploy
+Everything else:    denied (default allow := false) — no writes, no deletes, no other environments
+```
+
+Get explicit "yes, create it" before Phase 4. Carry the final policy string into Phase 3 for local testing.

--- a/qovery-policy-token/reference/phase2-authoring-rego.md
+++ b/qovery-policy-token/reference/phase2-authoring-rego.md
@@ -87,6 +87,63 @@ allow if {
 
 Combine rules with multiple `allow if` blocks (OR) to build "read this env AND deploy this service AND modify that service but never delete" — see the composite starter policy in the API Policy Token docs.
 
+## 2.3b Capability → Rego building-block library
+
+This is how you turn the Phase 1 interview into a **complete** policy: pick a **scope predicate** (from Step B) and one block per **capability** (from Step C), substitute the confirmed UUIDs, and OR them together under a single `default allow := false`.
+
+**Scope predicate `<SCOPE>`** — the same line goes into every block:
+
+| Step B answer | `<SCOPE>` line |
+|---|---|
+| one service | `input.qovery_metadata.service_id == allowed_service_id` |
+| one environment | `input.qovery_metadata.environment_id == allowed_environment_id` |
+| one project | `input.qovery_metadata.project_id == allowed_project_id` |
+| whole org | *(omit — no resource scope; broad, confirm twice)* |
+
+Qovery resolves `qovery_metadata` (including `project_id`) from the request path for action routes too — this is verified live: a project-scoped clone/deploy policy correctly permits those actions and denies the same actions in other projects.
+
+**Capability blocks** — the API paths below are verified against the live API. `<SCOPE>` = the line from the table above.
+
+| Capability | Block |
+|---|---|
+| **Read / observe** | `allow if { input.request.method in {"GET","HEAD"}; <SCOPE> }` |
+| **Deploy / lifecycle an environment** (pick the actions you want from the set) | `env_actions := {"deploy","redeploy","stop","restart","cancelDeployment"}`<br>`allow if { input.request.method == "POST"; <SCOPE>; input.request.path[1] == "environment"; input.request.path[3] in env_actions; count(input.request.path) == 4 }` |
+| **Clone an environment** | `allow if { input.request.method == "POST"; <SCOPE>; input.request.path[1] == "environment"; input.request.path[3] == "clone"; count(input.request.path) == 4 }` |
+| **Deploy a specific service** (app/container/job/database/helm) | `service_kinds := {"application","container","job","database","helm"}`<br>`allow if { input.request.method == "POST"; input.qovery_metadata.service_id == allowed_service_id; input.request.path[1] in service_kinds; input.request.path[3] == "deploy"; count(input.request.path) == 4 }` |
+| **Deploy selected services in an env** | `allow if { input.request.method == "POST"; <SCOPE>; input.request.path == ["api","environment", input.request.path[2], "service","deploy"] }` |
+| **Manage env vars, constrained** | `allow if { input.request.method == "POST"; input.qovery_metadata.service_id == allowed_service_id; input.request.path[3] == "environmentVariable"; startswith(input.request.body.key, "FEATURE_") }` |
+| **Everything except delete** on a scope | `allow if { input.request.method != "DELETE"; <SCOPE> }` |
+
+**Assembly procedure:**
+1. Emit `default allow := false` and one constant per resolved UUID (`allowed_project_id := "…"`, etc.).
+2. For each capability the user picked, paste its block and substitute `<SCOPE>` and the constant names.
+3. Keep the `env_actions` / `service_kinds` set to only the actions the user actually asked for (trim the set).
+4. Multiple blocks = OR, which is exactly "can do A **or** B". Run Phase 3 to prove the whole thing.
+
+**Worked example** — "clone and deploy any environment in one project, and nothing else" (verified end-to-end live) — `templates/policies/clone-deploy-project.rego`:
+
+```rego
+default allow := false
+
+allowed_project_id := "<PROJECT_UUID>"
+
+allow if {   # deploy any environment in the project
+	input.request.method == "POST"
+	input.qovery_metadata.project_id == allowed_project_id
+	input.request.path[1] == "environment"
+	input.request.path[3] == "deploy"
+	count(input.request.path) == 4
+}
+
+allow if {   # clone any environment in the project
+	input.request.method == "POST"
+	input.qovery_metadata.project_id == allowed_project_id
+	input.request.path[1] == "environment"
+	input.request.path[3] == "clone"
+	count(input.request.path) == 4
+}
+```
+
 ## 2.4 Common pitfalls
 
 - **Over-broad reads.** `method == "GET"` with no resource scope lets the token read the *entire org*. Always pair a method check with an environment/service scope unless org-wide read is truly intended.

--- a/qovery-policy-token/reference/phase3-local-testing.md
+++ b/qovery-policy-token/reference/phase3-local-testing.md
@@ -1,0 +1,82 @@
+# Phase 3 — Local Pre-flight Testing with OPA
+
+Prove the policy does exactly what the user expects **before** creating the token. Because policies are immutable, this is the cheapest place to catch a mistake — a wrong rule here costs one edit; a wrong rule after creation costs a delete + recreate.
+
+Qovery has **no server-side simulate endpoint**, so local testing uses the same OPA engine Qovery runs (OPA 1.19), evaluating the policy against synthetic `input` documents that mirror real requests.
+
+## 3.1 Check for OPA (best-effort)
+
+```bash
+opa version    # expect 1.19.x (the version Qovery runs)
+```
+
+If OPA is missing, offer to install it, or skip to Phase 5 live verification:
+
+```bash
+# macOS
+brew install opa
+# Linux (x86_64)
+curl -L -o /usr/local/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static && chmod +x /usr/local/bin/opa
+```
+
+If the user declines to install OPA, note in the plan that the policy could not be statically verified and that Phase 5 (live) will do the DENY checks and safe ALLOW checks instead — but static verification of *destructive allowed* actions won't be possible, so extra care is warranted before granting them.
+
+## 3.2 Build the allow/deny test matrix
+
+The matrix is the Phase 1 allow-list + deny-list turned into concrete `input` documents, each with an expected boolean. Copy `templates/test-matrix.example.json` and edit it. Each case:
+
+```json
+{
+  "name": "read staging env (allow)",
+  "expect": true,
+  "live": { "method": "GET", "path": "/environment/<ENV_UUID>/service", "destructive": false },
+  "input": {
+    "request": { "method": "GET", "path": ["api", "environment", "<ENV_UUID>", "service"], "body": null },
+    "qovery_metadata": {
+      "organization_id": "<ORG_UUID>", "environment_id": "<ENV_UUID>",
+      "project_id": "<PROJ_UUID>", "service_id": null, "service_type": null, "cluster_id": "<CLUSTER_UUID>"
+    },
+    "token": { "id": "00000000-0000-0000-0000-000000000000", "name": "preflight" }
+  }
+}
+```
+
+Cover, at minimum:
+- **One allow case per rule** the user asked for (expect `true`).
+- **One deny case per item on the deny-list** — e.g. a `DELETE` on the allowed service, a write to another environment, a read of a different env (expect `false`).
+- **Boundary cases** the user cares about — the exact thing that must never happen. If the user said "never delete", include a `DELETE` that targets the *allowed* service and assert it's denied.
+
+A policy that passes its allow cases but has no deny cases is not verified — the deny cases are what prove it isn't over-broad.
+
+## 3.3 Run the pre-flight
+
+```bash
+bash templates/scripts/opa-preflight.sh policy.rego test-matrix.json
+```
+
+The script (`templates/scripts/opa-preflight.sh`):
+1. Runs `opa check` on the policy (syntax/compile — the same class of error the API returns as `400`).
+2. Prepends a temporary `package qovery.policy` to a scratch copy so `opa eval` can address the rule (the submitted `opa_policy` must NOT contain a package line — the create step uses the original file).
+3. For each matrix case, runs `opa eval -d <scratch> -i <case-input> --format raw 'data.qovery.policy.allow'` and compares the boolean to `expect`.
+4. Prints a pass/fail table and exits non-zero if any case fails.
+
+Example output:
+
+```
+CASE                                  EXPECT  ACTUAL  RESULT
+read staging env (allow)              true    true    PASS
+deploy api service (allow)            true    true    PASS
+delete api service (deny)             false   false   PASS
+write to production (deny)            false   false   PASS
+read other environment (deny)        false   false   PASS
+
+5/5 passed
+```
+
+## 3.4 Iterate until green
+
+If any case fails, the policy is wrong — fix the Rego (Phase 2) and re-run. Do **not** proceed to Phase 4 with a red matrix. Common fixes:
+- Allow case failing → the rule's condition is too strict or references a wrong UUID.
+- Deny case passing as allow → a rule is broader than intended (e.g. an unscoped `GET`); tighten it.
+
+Once the matrix is fully green and the user has confirmed the policy (Phase 2.5), continue to Phase 4. Keep `policy.rego` and `test-matrix.json` — Phase 5 reuses the same matrix for live verification.

--- a/qovery-policy-token/reference/phase4-create-token.md
+++ b/qovery-policy-token/reference/phase4-create-token.md
@@ -1,0 +1,64 @@
+# Phase 4 — Create the Policy Token
+
+Only reach this phase when: (a) the local matrix is fully green (Phase 3), and (b) the user has explicitly confirmed the policy (Phase 2.5). Creation is a one-way step for the policy — there is no edit endpoint, so a wrong policy means deleting this token and creating another.
+
+## 4.1 The create endpoint
+
+```
+POST https://api.qovery.com/organization/{organizationId}/policyApiToken
+Authorization: Token $QOVERY_API_TOKEN        # a regular OWNER/ADMIN token
+Content-Type: application/json
+```
+
+Request body:
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | yes | Unique within the org (`409` if taken) |
+| `description` | no | What the token is for — shows in the Console and audit context |
+| `opa_policy` | yes | The Rego policy as a string, **without** a `package` line |
+| `expires_at` | no | RFC 3339 timestamp; omit or `null` for no expiry |
+
+Response (2xx) includes: `id` (the token UUID — keep it, needed to revoke), `name`, `description`, `created_at`, and **`token`** — the secret value (`sk-qov-01-...`), used later as `Authorization: Token <token>`. **This is the only response that ever contains the token value.**
+
+## 4.2 Create without exposing the secret
+
+Use `templates/scripts/create-policy-token.sh` — it POSTs the policy and captures both `id` and `token` into shell state without ever printing the secret:
+
+```bash
+bash templates/scripts/create-policy-token.sh "$QOVERY_ORG_ID" "deploy-agent" policy.rego \
+  "Deploys the staging environment"       # optional description
+  # optional 5th arg: expires_at (RFC 3339)
+```
+
+The script:
+1. Reads `policy.rego`, verifies it has **no** `package` line (else the API returns `400`), and JSON-encodes it with `jq` (so newlines/quotes are escaped correctly).
+2. POSTs with the `Authorization: Token` + `User-Agent` headers.
+3. On success, writes the token to a shell env file the *user* controls and never echoes it — following the secrecy rules in `auth.md`. It prints only the non-secret `id`, `name`, and a masked confirmation.
+4. On error, prints the HTTP status and the specific remedy below.
+
+> **Token-secrecy rules (from `auth.md`) apply in full here.** Never `echo` the token, never store it in a variable the agent then prints, never write it into a repo file or generated script. Refer to it as `***`. It flows into the Phase 5 live-verify inline via an env var.
+
+## 4.3 Error handling
+
+| Status | Meaning | What to do |
+|---|---|---|
+| `400` | Policy is empty, > 65,536 chars, contains a `package` line, or does not compile | Re-check with `opa check` (Phase 3). Remove any `package` line. Fix the compile error the response reports. |
+| `403` | Caller is not an org Owner or Admin | The regular API token used to create lacks permission. Ask the user for an owner/admin token, or have an admin run the create. |
+| `409` | A policy token with that `name` already exists | Choose a different `name`, or list existing tokens (Phase 6) and revoke/reuse. |
+
+## 4.4 Manual equivalent (for transparency)
+
+If the user wants to see the raw call (do **not** paste a real token into the conversation):
+
+```bash
+POLICY_JSON=$(jq -Rs . < policy.rego)     # JSON-encode the rego file
+curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/policyApiToken" \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"name\":\"deploy-agent\",\"description\":\"Deploys staging\",\"opa_policy\":${POLICY_JSON}}"
+# The response .token is the secret — never print it; capture inline.
+```
+
+Carry the token `id` (non-secret) into Phase 6, and the token value (secret, in an env var) into Phase 5.

--- a/qovery-policy-token/reference/phase4-create-token.md
+++ b/qovery-policy-token/reference/phase4-create-token.md
@@ -33,7 +33,7 @@ bash templates/scripts/create-policy-token.sh "$QOVERY_ORG_ID" "deploy-agent" po
 
 The script:
 1. Reads `policy.rego`, verifies it has **no** `package` line (else the API returns `400`), and JSON-encodes it with `jq` (so newlines/quotes are escaped correctly).
-2. POSTs with the `Authorization: Token` + `User-Agent` headers.
+2. POSTs with the `User-Agent` header and owner/admin auth: `Authorization: Token $QOVERY_API_TOKEN` if set, otherwise falling back to the CLI's OIDC session (`Authorization: Bearer $(qovery auth token --print)`, used inline). Either works — the API accepts an API token or an OIDC Bearer for an owner/admin.
 3. On success, writes the token to a shell env file the *user* controls and never echoes it — following the secrecy rules in `auth.md`. It prints only the non-secret `id`, `name`, and a masked confirmation.
 4. On error, prints the HTTP status and the specific remedy below.
 

--- a/qovery-policy-token/reference/phase5-live-verify.md
+++ b/qovery-policy-token/reference/phase5-live-verify.md
@@ -1,0 +1,55 @@
+# Phase 5 — Live Verification
+
+Prove the freshly-created token behaves against the real API exactly as the local matrix predicted. This closes the loop on "verify the policy does exactly what the user expects" — the local OPA pass (Phase 3) checks the policy logic; this checks that Qovery evaluates it the same way end-to-end.
+
+## 5.1 Why deny-testing is safe and allow-destructive-testing is not
+
+Qovery evaluates the policy **at authentication time, before the request reaches its endpoint.** A denied request returns `401` and **never executes** — so it is completely safe to fire a real `DELETE`, `POST`, or any mutating request that the policy should block: the resource is never touched. This lets us live-verify the entire deny-list for real.
+
+The opposite is not safe. An *allowed* mutating request (deploy, delete, scale, update) **will execute** if the policy permits it. So the live test:
+
+- **Runs every DENY case live** — expect HTTP `401`.
+- **Runs non-destructive ALLOW cases live** — `GET`/`HEAD` reads the policy should permit; expect `2xx`.
+- **Does NOT auto-run destructive ALLOW cases** — a `POST deploy`, `DELETE`, `PUT`, etc. that the policy allows. These were already verified statically in Phase 3. The harness lists them as "verified statically; run manually to confirm end-to-end" and only executes one if the user explicitly opts in for that specific action.
+
+## 5.2 Run the live verification
+
+`live-verify.sh` reads the same `test-matrix.json` from Phase 3 (the `live` block on each case) and the token from an env var (never a CLI arg, so it doesn't land in shell history):
+
+```bash
+# Capture the token inline into an env var the agent does not print (set by create-policy-token.sh,
+# or sourced from the user's secure env file). Then:
+bash templates/scripts/live-verify.sh test-matrix.json
+```
+
+For each case the script:
+1. Builds the request from the `live` block: `{method, path, body?, destructive}`.
+2. **Deny case** (`expect: false`): sends it, asserts HTTP `401` (blocked at auth, never executed). PASS if `401`.
+3. **Allow + non-destructive** (`expect: true`, `destructive: false`): sends it, asserts `2xx`. PASS if `2xx`.
+4. **Allow + destructive** (`expect: true`, `destructive: true`): **skips execution**, marks `SKIPPED (static-only)`, and reminds that Phase 3 already proved the allow decision. Runs it only if the user passed `--run-destructive` and confirmed that specific action.
+
+It uses `Authorization: Token $POLICY_TOKEN` (the policy token, not the admin token) plus the standard `User-Agent` header, and prints a report table.
+
+Example:
+
+```
+CASE                              KIND              EXPECT  STATUS  RESULT
+read staging env                  allow/read        2xx     200     PASS
+deploy api service                allow/destructive  —       —      SKIPPED (verified statically)
+delete api service                deny              401     401     PASS
+write to production               deny              401     401     PASS
+read other environment            deny              401     401     PASS
+
+4/4 executable checks passed, 1 skipped (destructive allow)
+```
+
+## 5.3 Interpreting results
+
+- **A deny case returns something other than `401`** (e.g. `200`, `403`, `404`) → the policy is NOT blocking it the way the user wants. This is a real failure: the policy is too permissive (or the request didn't resolve the metadata you assumed). Revisit Phase 2, delete this token (Phase 6), fix, and recreate. Do **not** hand over a token that failed a deny check.
+- **An allow/read case returns `401`** → the policy is too restrictive; the token can't do what the user needs. Same remediation: fix and recreate.
+- **A `404` on an allow case** usually means a wrong path/UUID in the matrix, not a policy problem — fix the matrix and re-run.
+- **Destructive allow cases** remain SKIPPED unless the user opts in. If they want full end-to-end proof of, say, a deploy, run that one action with their confirmation and confirm the deploy started.
+
+## 5.4 Report
+
+Summarize for the user: the token allows exactly the confirmed allow-list (reads verified live, destructive actions verified statically) and denies the confirmed deny-list (verified live at `401`). Only after this passes, proceed to Phase 6 to hand over the token. If anything failed, treat the token as unusable — revoke it and iterate.

--- a/qovery-policy-token/reference/phase6-lifecycle.md
+++ b/qovery-policy-token/reference/phase6-lifecycle.md
@@ -1,0 +1,57 @@
+# Phase 6 — Deliver the Token and Manage its Lifecycle
+
+The policy is verified and the token works. Hand it over correctly and make sure the user knows how to operate it — it can't be retrieved again, and its policy can't be edited.
+
+## 6.1 Deliver the token once
+
+The token value was shown only in the create response and can never be fetched again. Deliver it to the user through a channel the agent does not print into the conversation:
+
+- Prefer having `create-policy-token.sh` write it to a user-controlled secure location (e.g. a gitignored `.env` the agent does not read back), and tell the user where it is.
+- If you must reference it, use `***` — never the real value.
+- Remind the user to store it in their secret manager / CI secret store immediately, and that Qovery cannot recover it if lost (they'd delete and recreate).
+
+Give them the non-secret facts to keep:
+- token `id` (UUID) — needed to revoke
+- `name`, `description`, and `expires_at` (if set)
+- how the token is used: `Authorization: Token <the-secret>`
+
+## 6.2 Immutability — how to "change" a policy
+
+There is **no update endpoint**. To change what the token can do, delete it and create a new one (rerun Phases 2–5). Set expectations: this means rotating the secret too, so anywhere the old token is configured must be updated.
+
+## 6.3 List policy tokens
+
+```bash
+curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  "https://api.qovery.com/organization/${QOVERY_ORG_ID}/policyApiToken" \
+  | jq '.results[] | {id, name, description, expires_at}'
+```
+
+The list returns each token's `opa_policy` (so you can review what a token allows) but **never** the token value.
+
+## 6.4 Revoke a policy token
+
+Revocation is immediate (no caching) — the token stops working on the next request.
+
+```bash
+curl -s -X DELETE \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  "https://api.qovery.com/organization/${QOVERY_ORG_ID}/policyApiToken/${POLICY_TOKEN_ID}"
+```
+
+Use this to: fix a policy (delete + recreate), retire an agent, or respond to a suspected leak. If you created a **test** token during verification, revoke it here as cleanup.
+
+## 6.5 Audit trail
+
+Actions taken with a policy token are attributed in the Qovery audit log as `policy:<token-id>:<token-name>`. Tell the user this so they can trace what the token did — and pick a descriptive `name` at creation time (Phase 4) precisely so the audit log is legible.
+
+## 6.6 Wrap-up checklist to give the user
+
+- [ ] Token stored in a secret manager (it can't be retrieved again)
+- [ ] token `id` recorded (needed to revoke)
+- [ ] Understands the policy is immutable — changes mean delete + recreate + re-store the secret
+- [ ] Knows how to list (`GET .../policyApiToken`) and revoke (`DELETE .../policyApiToken/{id}`)
+- [ ] Any test token created during verification has been revoked
+- [ ] Expiry set if appropriate (agent tokens especially)

--- a/qovery-policy-token/templates/policies/body-constrained-env-var.rego
+++ b/qovery-policy-token/templates/policies/body-constrained-env-var.rego
@@ -1,0 +1,14 @@
+# Constrain the request body: allow creating environment variables on ONE application,
+# but only those whose key starts with "FEATURE_".
+# Replace <APP_UUID> with the real application UUID resolved in Phase 1.
+# Do NOT add a `package` line — Qovery injects one per token.
+
+default allow := false
+
+allowed_application_id := "<APP_UUID>"
+
+allow if {
+	input.request.method == "POST"
+	input.request.path == ["api", "application", allowed_application_id, "environmentVariable"]
+	startswith(input.request.body.key, "FEATURE_")
+}

--- a/qovery-policy-token/templates/policies/clone-deploy-project.rego
+++ b/qovery-policy-token/templates/policies/clone-deploy-project.rego
@@ -1,0 +1,30 @@
+# Clone and deploy ANY environment in one project — and nothing else.
+# Scope is the project: input.qovery_metadata.project_id resolves from the request path for
+# clone/deploy action routes (verified live), so this covers every environment under the project,
+# including freshly cloned ones. Reads, deletes, stops, and other projects are all denied by default.
+# Replace <PROJECT_UUID> with the real project UUID resolved in Phase 1.
+# Do NOT add a `package` line — Qovery injects one per token.
+
+default allow := false
+
+allowed_project_id := "<PROJECT_UUID>"
+
+# Deploy any environment in the project:  POST /environment/{id}/deploy
+allow if {
+	input.request.method == "POST"
+	input.qovery_metadata.project_id == allowed_project_id
+	input.request.path[0] == "api"
+	input.request.path[1] == "environment"
+	input.request.path[3] == "deploy"
+	count(input.request.path) == 4
+}
+
+# Clone any environment in the project:  POST /environment/{id}/clone
+allow if {
+	input.request.method == "POST"
+	input.qovery_metadata.project_id == allowed_project_id
+	input.request.path[0] == "api"
+	input.request.path[1] == "environment"
+	input.request.path[3] == "clone"
+	count(input.request.path) == 4
+}

--- a/qovery-policy-token/templates/policies/deploy-only.rego
+++ b/qovery-policy-token/templates/policies/deploy-only.rego
@@ -1,0 +1,15 @@
+# Deploy a specific service/application and nothing else.
+# Replace <ENV_UUID> and <APP_UUID> with real UUIDs resolved in Phase 1.
+# Keep only the rule(s) that match the deploy route you intend to allow.
+# Do NOT add a `package` line — Qovery injects one per token.
+
+default allow := false
+
+allowed_environment_id := "<ENV_UUID>"
+allowed_application_id := "<APP_UUID>"
+
+# Deploy a single service within the environment
+allow if input.request.path == ["api", "environment", allowed_environment_id, "service", "deploy"]
+
+# Deploy a single application directly
+allow if input.request.path == ["api", "application", allowed_application_id, "deploy"]

--- a/qovery-policy-token/templates/policies/modify-one-service-never-delete.rego
+++ b/qovery-policy-token/templates/policies/modify-one-service-never-delete.rego
@@ -1,0 +1,14 @@
+# Change one service in any way EXCEPT delete it.
+# Replace <APP_UUID> with the real service UUID resolved in Phase 1.
+# NOTE: `method != "DELETE"` blocks HTTP DELETE only. If a destructive action on this
+# service is exposed as POST/PUT and you must block it too, scope more tightly or add
+# an explicit path guard. Do NOT add a `package` line — Qovery injects one per token.
+
+default allow := false
+
+allowed_application_id := "<APP_UUID>"
+
+allow if {
+	input.request.method != "DELETE"
+	input.qovery_metadata.service_id == allowed_application_id
+}

--- a/qovery-policy-token/templates/policies/read-only-env.rego
+++ b/qovery-policy-token/templates/policies/read-only-env.rego
@@ -1,0 +1,13 @@
+# Read-only access to a single environment.
+# The token can GET/HEAD anything scoped to <ENV_UUID> and nothing else.
+# Replace <ENV_UUID> with the real environment UUID resolved in Phase 1.
+# Do NOT add a `package` line — Qovery injects one per token.
+
+default allow := false
+
+allowed_environment_id := "<ENV_UUID>"
+
+allow if {
+	input.request.method in {"GET", "HEAD"}
+	input.qovery_metadata.environment_id == allowed_environment_id
+}

--- a/qovery-policy-token/templates/scripts/create-policy-token.sh
+++ b/qovery-policy-token/templates/scripts/create-policy-token.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# create-policy-token.sh — create a Qovery API Policy Token from a Rego file.
+#
+# Usage:
+#   bash create-policy-token.sh <organizationId> <name> <policy.rego> [description] [expires_at]
+#
+# Requires an OWNER/ADMIN Qovery API token in $QOVERY_API_TOKEN (used to authorize creation).
+# Writes the ONE-TIME secret token to a gitignored env file the caller controls and NEVER
+# prints it. Prints only the non-secret id/name. Handles 400/403/409 with specific guidance.
+#
+# SECURITY: this script never echoes the token value. Do not add `echo`/`cat` of the token
+# or of the output file. Refer to the token as *** everywhere.
+set -euo pipefail
+
+ORG_ID="${1:?usage: create-policy-token.sh <organizationId> <name> <policy.rego> [description] [expires_at]}"
+NAME="${2:?missing token name}"
+POLICY="${3:?missing policy.rego path}"
+DESCRIPTION="${4:-}"
+EXPIRES_AT="${5:-}"
+
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq not found."; exit 2; }
+[ -f "$POLICY" ] || { echo "ERROR: policy file not found: $POLICY"; exit 2; }
+[ -n "${QOVERY_API_TOKEN:-}" ] || { echo "ERROR: QOVERY_API_TOKEN (owner/admin) not set."; exit 2; }
+
+if grep -qE '^\s*package\s' "$POLICY"; then
+  echo "ERROR: $POLICY contains a 'package' line — Qovery returns 400. Remove it and re-run."
+  exit 2
+fi
+
+BYTES="$(wc -c < "$POLICY" | tr -d ' ')"
+if [ "$BYTES" -gt 65536 ]; then
+  echo "ERROR: policy is $BYTES bytes; the maximum is 65536."
+  exit 2
+fi
+
+VERSION="$(cat _version.txt 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+UA="QoverySkill/qovery-policy-token (version:${VERSION}; https://github.com/Qovery/qovery-skills)"
+
+# Build the JSON body with jq so the rego string is safely encoded (newlines/quotes).
+BODY="$(jq -n \
+  --arg name "$NAME" \
+  --arg description "$DESCRIPTION" \
+  --rawfile opa_policy "$POLICY" \
+  --arg expires_at "$EXPIRES_AT" \
+  '{name: $name, opa_policy: $opa_policy}
+   + (if $description == "" then {} else {description: $description} end)
+   + (if $expires_at  == "" then {} else {expires_at:  $expires_at}  end)')"
+
+RESP="$(curl -s -w $'\n%{http_code}' -X POST \
+  "https://api.qovery.com/organization/${ORG_ID}/policyApiToken" \
+  -H "Authorization: Token ${QOVERY_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: ${UA}" \
+  -d "$BODY")"
+
+HTTP_CODE="$(printf '%s' "$RESP" | tail -n1)"
+PAYLOAD="$(printf '%s' "$RESP" | sed '$d')"   # everything except the last line (never printed on success)
+
+case "$HTTP_CODE" in
+  2*)
+    ID="$(printf '%s' "$PAYLOAD" | jq -r '.id')"
+    OUT_NAME="$(printf '%s' "$PAYLOAD" | jq -r '.name')"
+    OUT_FILE="${POLICY_TOKEN_ENV_FILE:-.qovery-policy-token.env}"
+    # Write the secret to a caller-controlled file WITHOUT printing it.
+    umask 077
+    printf 'POLICY_TOKEN=%s\n' "$(printf '%s' "$PAYLOAD" | jq -r '.token')" > "$OUT_FILE"
+    # Best-effort: keep the secret out of git.
+    if [ -d .git ] && ! grep -qxF "$OUT_FILE" .gitignore 2>/dev/null; then
+      printf '%s\n' "$OUT_FILE" >> .gitignore
+    fi
+    echo "Created policy token '${OUT_NAME}' (id: ${ID})."
+    echo "Secret written to ${OUT_FILE} (chmod 600, gitignored) — value is ***, never printed."
+    echo "For live verification (Phase 5):  set -a; . ${OUT_FILE}; set +a"
+    echo "Store it in your secret manager now — Qovery cannot show it again."
+    ;;
+  400) echo "ERROR 400: policy is empty, oversized, declares a 'package', or does not compile."; echo "Re-run opa-preflight.sh and remove any package line."; exit 1 ;;
+  403) echo "ERROR 403: the caller is not an org Owner or Admin. Use an owner/admin API token to create policy tokens."; exit 1 ;;
+  409) echo "ERROR 409: a policy token named '${NAME}' already exists. Choose a different name or revoke the existing one."; exit 1 ;;
+  *)   echo "ERROR ${HTTP_CODE}: unexpected response creating the policy token."; exit 1 ;;
+esac

--- a/qovery-policy-token/templates/scripts/create-policy-token.sh
+++ b/qovery-policy-token/templates/scripts/create-policy-token.sh
@@ -4,7 +4,8 @@
 # Usage:
 #   bash create-policy-token.sh <organizationId> <name> <policy.rego> [description] [expires_at]
 #
-# Requires an OWNER/ADMIN Qovery API token in $QOVERY_API_TOKEN (used to authorize creation).
+# Authorizes creation with owner/admin credentials: an API token in $QOVERY_API_TOKEN (Token
+# scheme) if set, otherwise the CLI's OIDC session (`qovery auth`, Bearer scheme).
 # Writes the ONE-TIME secret token to a gitignored env file the caller controls and NEVER
 # prints it. Prints only the non-secret id/name. Handles 400/403/409 with specific guidance.
 #
@@ -20,7 +21,16 @@ EXPIRES_AT="${5:-}"
 
 command -v jq >/dev/null 2>&1 || { echo "ERROR: jq not found."; exit 2; }
 [ -f "$POLICY" ] || { echo "ERROR: policy file not found: $POLICY"; exit 2; }
-[ -n "${QOVERY_API_TOKEN:-}" ] || { echo "ERROR: QOVERY_API_TOKEN (owner/admin) not set."; exit 2; }
+
+# Admin credential: prefer an owner/admin API token (Token scheme); otherwise fall back to the
+# CLI's OIDC session (Bearer scheme) — used inline so the value is never printed or persisted.
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  AUTH=(-H "Authorization: Token ${QOVERY_API_TOKEN}")
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  AUTH=(-H "Authorization: Bearer $(qovery auth token --print)")
+else
+  echo "ERROR: no admin credential. Set QOVERY_API_TOKEN (owner/admin) or run 'qovery auth' first."; exit 2
+fi
 
 if grep -qE '^\s*package\s' "$POLICY"; then
   echo "ERROR: $POLICY contains a 'package' line — Qovery returns 400. Remove it and re-run."
@@ -48,7 +58,7 @@ BODY="$(jq -n \
 
 RESP="$(curl -s -w $'\n%{http_code}' -X POST \
   "https://api.qovery.com/organization/${ORG_ID}/policyApiToken" \
-  -H "Authorization: Token ${QOVERY_API_TOKEN}" \
+  "${AUTH[@]}" \
   -H "Content-Type: application/json" \
   -H "User-Agent: ${UA}" \
   -d "$BODY")"

--- a/qovery-policy-token/templates/scripts/live-verify.sh
+++ b/qovery-policy-token/templates/scripts/live-verify.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# live-verify.sh — verify a live Qovery policy token against the test matrix.
+#
+# Usage:
+#   set -a; . .qovery-policy-token.env; set +a      # loads $POLICY_TOKEN (the policy token secret)
+#   bash live-verify.sh <test-matrix.json> [--run-destructive]
+#
+# Safe by design:
+#   * DENY cases (expect=false) are sent for real — Qovery blocks them at auth (401) BEFORE the
+#     request reaches the endpoint, so nothing executes. We assert HTTP 401.
+#   * ALLOW + non-destructive cases (GET/HEAD) are sent and asserted 2xx.
+#   * ALLOW + destructive cases are SKIPPED (already proven statically by opa-preflight.sh) unless
+#     --run-destructive is passed AND you accept they will actually execute.
+#
+# Requires: $POLICY_TOKEN (the policy token, NOT the admin token) and jq.
+# SECURITY: this script never prints $POLICY_TOKEN.
+set -euo pipefail
+
+MATRIX="${1:?usage: live-verify.sh <test-matrix.json> [--run-destructive]}"
+RUN_DESTRUCTIVE="no"
+[ "${2:-}" = "--run-destructive" ] && RUN_DESTRUCTIVE="yes"
+
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq not found."; exit 2; }
+[ -f "$MATRIX" ] || { echo "ERROR: matrix not found: $MATRIX"; exit 2; }
+[ -n "${POLICY_TOKEN:-}" ] || { echo "ERROR: POLICY_TOKEN not set. Source the env file written by create-policy-token.sh first."; exit 2; }
+
+VERSION="$(cat _version.txt 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+UA="QoverySkill/qovery-policy-token (version:${VERSION}; https://github.com/Qovery/qovery-skills)"
+BASE="https://api.qovery.com"
+
+send() { # method path body -> prints http_code
+  local method="$1" path="$2" body="$3"
+  if [ "$body" = "null" ] || [ -z "$body" ]; then
+    curl -s -o /dev/null -w '%{http_code}' -X "$method" "${BASE}${path}" \
+      -H "Authorization: Token ${POLICY_TOKEN}" -H "User-Agent: ${UA}"
+  else
+    curl -s -o /dev/null -w '%{http_code}' -X "$method" "${BASE}${path}" \
+      -H "Authorization: Token ${POLICY_TOKEN}" -H "Content-Type: application/json" \
+      -H "User-Agent: ${UA}" -d "$body"
+  fi
+}
+
+N="$(jq '.cases | length' "$MATRIX")"
+printf '\n%-38s %-18s %-8s %-8s %s\n' "CASE" "KIND" "EXPECT" "STATUS" "RESULT"
+printf '%-38s %-18s %-8s %-8s %s\n' "$(printf '%.0s-' {1..38})" "----" "------" "------" "------"
+
+pass=0; fail=0; skipped=0
+for i in $(seq 0 $((N-1))); do
+  name="$(jq -r ".cases[$i].name" "$MATRIX")"
+  expect="$(jq -r ".cases[$i].expect" "$MATRIX")"
+  method="$(jq -r ".cases[$i].live.method" "$MATRIX")"
+  path="$(jq -r ".cases[$i].live.path" "$MATRIX")"
+  destructive="$(jq -r ".cases[$i].live.destructive // false" "$MATRIX")"
+  body="$(jq -c ".cases[$i].live.body // null" "$MATRIX")"
+
+  if [ "$expect" = "true" ] && [ "$destructive" = "true" ]; then
+    if [ "$RUN_DESTRUCTIVE" = "yes" ]; then
+      code="$(send "$method" "$path" "$body")"
+      if [[ "$code" =~ ^2 ]]; then result="PASS"; pass=$((pass+1)); else result="FAIL"; fail=$((fail+1)); fi
+      printf '%-38s %-18s %-8s %-8s %s\n' "$name" "allow/destructive" "2xx" "$code" "$result"
+    else
+      printf '%-38s %-18s %-8s %-8s %s\n' "$name" "allow/destructive" "—" "—" "SKIPPED (verified statically)"
+      skipped=$((skipped+1))
+    fi
+    continue
+  fi
+
+  code="$(send "$method" "$path" "$body")"
+  if [ "$expect" = "false" ]; then
+    # deny: must be blocked at auth (401), never executed
+    if [ "$code" = "401" ]; then result="PASS"; pass=$((pass+1)); else result="FAIL"; fail=$((fail+1)); fi
+    printf '%-38s %-18s %-8s %-8s %s\n' "$name" "deny" "401" "$code" "$result"
+  else
+    # allow + non-destructive read
+    if [[ "$code" =~ ^2 ]]; then result="PASS"; pass=$((pass+1)); else result="FAIL"; fail=$((fail+1)); fi
+    printf '%-38s %-18s %-8s %-8s %s\n' "$name" "allow/read" "2xx" "$code" "$result"
+  fi
+done
+
+echo
+echo "${pass} passed, ${fail} FAILED, ${skipped} skipped (destructive allow — verified statically in Phase 3)"
+if [ "$fail" -gt 0 ]; then
+  echo "A deny case that did not return 401 means the policy is too permissive; an allow/read that was not 2xx means it is too restrictive."
+  echo "Treat this token as unusable: revoke it (Phase 6), fix the policy (Phase 2), and recreate."
+  exit 1
+fi
+echo "Live behavior matches the matrix. Proceed to Phase 6 (deliver + lifecycle)."

--- a/qovery-policy-token/templates/scripts/opa-preflight.sh
+++ b/qovery-policy-token/templates/scripts/opa-preflight.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# opa-preflight.sh — locally verify a Qovery policy against an allow/deny test matrix.
+#
+# Usage: bash opa-preflight.sh <policy.rego> <test-matrix.json>
+#
+# For each case in the matrix it runs `opa eval` and compares the `allow` decision to the
+# expected boolean, then prints a pass/fail table. Exits non-zero if any case fails.
+#
+# Requires: opa (1.19 recommended, the version Qovery runs) and jq.
+# The submitted policy must NOT contain a `package` line; this script adds a temporary one
+# to a scratch copy so OPA can address the rule — it never modifies your original file.
+set -euo pipefail
+
+POLICY="${1:?usage: opa-preflight.sh <policy.rego> <test-matrix.json>}"
+MATRIX="${2:?usage: opa-preflight.sh <policy.rego> <test-matrix.json>}"
+
+command -v opa >/dev/null 2>&1 || { echo "ERROR: opa not found. Install OPA 1.19 (see phase3-local-testing.md) or skip to live verify."; exit 2; }
+command -v jq  >/dev/null 2>&1 || { echo "ERROR: jq not found."; exit 2; }
+[ -f "$POLICY" ] || { echo "ERROR: policy file not found: $POLICY"; exit 2; }
+[ -f "$MATRIX" ] || { echo "ERROR: matrix file not found: $MATRIX"; exit 2; }
+
+if grep -qE '^\s*package\s' "$POLICY"; then
+  echo "ERROR: $POLICY contains a 'package' line. Qovery rejects that on create (400). Remove it."
+  exit 2
+fi
+
+SCRATCH_DIR="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH_DIR"' EXIT
+SCRATCH_POLICY="$SCRATCH_DIR/policy.rego"
+{ printf 'package qovery.policy\n\n'; cat "$POLICY"; } > "$SCRATCH_POLICY"
+
+# Compile check (same class of error the API returns as 400)
+if ! opa check "$SCRATCH_POLICY"; then
+  echo "ERROR: policy failed 'opa check' — fix the compile error above before creating a token."
+  exit 1
+fi
+
+N="$(jq '.cases | length' "$MATRIX")"
+[ "$N" -gt 0 ] || { echo "ERROR: matrix has no cases."; exit 2; }
+
+printf '\n%-45s %-8s %-8s %s\n' "CASE" "EXPECT" "ACTUAL" "RESULT"
+printf '%-45s %-8s %-8s %s\n' "$(printf '%.0s-' {1..45})" "------" "------" "------"
+
+pass=0; fail=0
+for i in $(seq 0 $((N-1))); do
+  name="$(jq -r ".cases[$i].name" "$MATRIX")"
+  expect="$(jq -r ".cases[$i].expect" "$MATRIX")"
+  jq ".cases[$i].input" "$MATRIX" > "$SCRATCH_DIR/input.json"
+
+  # --format raw prints the raw value (true/false), or empty when undefined (treated as false/deny)
+  actual="$(opa eval -d "$SCRATCH_POLICY" -i "$SCRATCH_DIR/input.json" --format raw 'data.qovery.policy.allow' 2>/dev/null || true)"
+  [ -n "$actual" ] || actual="false"
+
+  if [ "$actual" = "$expect" ]; then
+    result="PASS"; pass=$((pass+1))
+  else
+    result="FAIL"; fail=$((fail+1))
+  fi
+  printf '%-45s %-8s %-8s %s\n' "$name" "$expect" "$actual" "$result"
+done
+
+echo
+echo "$pass/$N passed$([ "$fail" -gt 0 ] && echo ", $fail FAILED")"
+[ "$fail" -eq 0 ] || { echo "Policy is NOT ready — fix the failing rules (phase2) and re-run before creating a token."; exit 1; }
+echo "All cases green. Confirm the policy with the user, then proceed to Phase 4 (create)."

--- a/qovery-policy-token/templates/scripts/opa-preflight.sh
+++ b/qovery-policy-token/templates/scripts/opa-preflight.sh
@@ -35,7 +35,8 @@ if ! opa check "$SCRATCH_POLICY"; then
   exit 1
 fi
 
-N="$(jq '.cases | length' "$MATRIX")"
+N="$(jq '.cases | length' "$MATRIX" 2>/dev/null || true)"
+[[ "$N" =~ ^[0-9]+$ ]] || { echo "ERROR: $MATRIX is not valid JSON or has no .cases array."; exit 2; }
 [ "$N" -gt 0 ] || { echo "ERROR: matrix has no cases."; exit 2; }
 
 printf '\n%-45s %-8s %-8s %s\n' "CASE" "EXPECT" "ACTUAL" "RESULT"

--- a/qovery-policy-token/templates/test-matrix.example.json
+++ b/qovery-policy-token/templates/test-matrix.example.json
@@ -1,0 +1,90 @@
+{
+  "_comment": "Test matrix for a policy that allows read-only on one env + deploy one service, and denies everything else. Copy this file, replace every <...UUID> with real IDs from Phase 1, and edit the cases to match your policy's allow-list + deny-list. `input` drives local OPA eval (Phase 3); `live` drives the real API probe (Phase 5). Include at least one allow case per rule and one deny case per deny-list item.",
+  "cases": [
+    {
+      "name": "read staging services (allow)",
+      "expect": true,
+      "live": { "method": "GET", "path": "/environment/<ENV_UUID>/service", "destructive": false },
+      "input": {
+        "request": { "method": "GET", "path": ["api", "environment", "<ENV_UUID>", "service"], "body": null },
+        "qovery_metadata": {
+          "organization_id": "<ORG_UUID>",
+          "environment_id": "<ENV_UUID>",
+          "project_id": "<PROJ_UUID>",
+          "service_id": null,
+          "service_type": null,
+          "cluster_id": "<CLUSTER_UUID>"
+        },
+        "token": { "id": "00000000-0000-0000-0000-000000000000", "name": "preflight" }
+      }
+    },
+    {
+      "name": "deploy api service (allow, destructive - static only)",
+      "expect": true,
+      "live": { "method": "POST", "path": "/environment/<ENV_UUID>/service/deploy", "body": {}, "destructive": true },
+      "input": {
+        "request": { "method": "POST", "path": ["api", "environment", "<ENV_UUID>", "service", "deploy"], "body": {} },
+        "qovery_metadata": {
+          "organization_id": "<ORG_UUID>",
+          "environment_id": "<ENV_UUID>",
+          "project_id": "<PROJ_UUID>",
+          "service_id": "<SVC_UUID>",
+          "service_type": "APPLICATION",
+          "cluster_id": "<CLUSTER_UUID>"
+        },
+        "token": { "id": "00000000-0000-0000-0000-000000000000", "name": "preflight" }
+      }
+    },
+    {
+      "name": "delete api service (deny)",
+      "expect": false,
+      "live": { "method": "DELETE", "path": "/application/<SVC_UUID>", "destructive": true },
+      "input": {
+        "request": { "method": "DELETE", "path": ["api", "application", "<SVC_UUID>"], "body": null },
+        "qovery_metadata": {
+          "organization_id": "<ORG_UUID>",
+          "environment_id": "<ENV_UUID>",
+          "project_id": "<PROJ_UUID>",
+          "service_id": "<SVC_UUID>",
+          "service_type": "APPLICATION",
+          "cluster_id": "<CLUSTER_UUID>"
+        },
+        "token": { "id": "00000000-0000-0000-0000-000000000000", "name": "preflight" }
+      }
+    },
+    {
+      "name": "write to production env (deny)",
+      "expect": false,
+      "live": { "method": "POST", "path": "/environment/<PROD_ENV_UUID>/service/deploy", "body": {}, "destructive": true },
+      "input": {
+        "request": { "method": "POST", "path": ["api", "environment", "<PROD_ENV_UUID>", "service", "deploy"], "body": {} },
+        "qovery_metadata": {
+          "organization_id": "<ORG_UUID>",
+          "environment_id": "<PROD_ENV_UUID>",
+          "project_id": "<PROJ_UUID>",
+          "service_id": null,
+          "service_type": null,
+          "cluster_id": "<CLUSTER_UUID>"
+        },
+        "token": { "id": "00000000-0000-0000-0000-000000000000", "name": "preflight" }
+      }
+    },
+    {
+      "name": "read a different environment (deny)",
+      "expect": false,
+      "live": { "method": "GET", "path": "/environment/<OTHER_ENV_UUID>/service", "destructive": false },
+      "input": {
+        "request": { "method": "GET", "path": ["api", "environment", "<OTHER_ENV_UUID>", "service"], "body": null },
+        "qovery_metadata": {
+          "organization_id": "<ORG_UUID>",
+          "environment_id": "<OTHER_ENV_UUID>",
+          "project_id": "<PROJ_UUID>",
+          "service_id": null,
+          "service_type": null,
+          "cluster_id": "<CLUSTER_UUID>"
+        },
+        "token": { "id": "00000000-0000-0000-0000-000000000000", "name": "preflight" }
+      }
+    }
+  ]
+}

--- a/qovery-policy-token/templates/test-matrix.example.json
+++ b/qovery-policy-token/templates/test-matrix.example.json
@@ -4,9 +4,9 @@
     {
       "name": "read staging services (allow)",
       "expect": true,
-      "live": { "method": "GET", "path": "/environment/<ENV_UUID>/service", "destructive": false },
+      "live": { "method": "GET", "path": "/environment/<ENV_UUID>/application", "destructive": false },
       "input": {
-        "request": { "method": "GET", "path": ["api", "environment", "<ENV_UUID>", "service"], "body": null },
+        "request": { "method": "GET", "path": ["api", "environment", "<ENV_UUID>", "application"], "body": null },
         "qovery_metadata": {
           "organization_id": "<ORG_UUID>",
           "environment_id": "<ENV_UUID>",

--- a/qovery-preview/reference/auth.md
+++ b/qovery-preview/reference/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/qovery-speedup/reference/auth.md
+++ b/qovery-speedup/reference/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/qovery-terraform/reference/auth.md
+++ b/qovery-terraform/reference/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/qovery-troubleshoot/reference/auth.md
+++ b/qovery-troubleshoot/reference/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/qovery/SKILL.md
+++ b/qovery/SKILL.md
@@ -69,6 +69,7 @@ Analyze the user's message and route to the appropriate specialized skill. **Aut
 | Deployments slow, build time, startup time | `qovery-speedup` | "deployment is slow", "speed up", "build takes too long", "startup time" |
 | Preview environment, PR environment, test branch | `qovery-preview` | "preview for PR-123", "test this branch", "preview environment", "clone for PR" |
 | Terraformize existing setup, convert to IaC | `qovery-terraform` | "terraformize", "convert to terraform", "export as IaC", "terraform manifests", "infrastructure as code" |
+| Scoped/least-privilege API token, OPA/Rego policy token | `qovery-policy-token` | "restricted token", "scoped token", "least-privilege token", "policy token", "OPA/Rego token", "token that can only deploy / never delete", "token for an AI agent" |
 
 ### Remote Development Environments (RDEs)
 
@@ -325,6 +326,7 @@ Quick reference for all specialized skills. When routing, tell the user which sk
 | `qovery-speedup` | Analyze and fix slow deployments and builds | "My builds are slow" |
 | `qovery-preview` | Preview environments for PRs with auto-shutdown | "Preview PR-123" |
 | `qovery-terraform` | Generate Terraform manifests from existing Qovery setup | "Terraformize my setup" |
+| `qovery-policy-token` | Create and verify a scoped, least-privilege API Policy Token (OPA/Rego) | "Restricted token that can only deploy" |
 
 ---
 

--- a/qovery/reference/auth.md
+++ b/qovery/reference/auth.md
@@ -4,13 +4,16 @@
 
 **CRITICAL: NEVER display, log, print, or capture Qovery token values.**
 
-- NEVER run `qovery auth token --print` as a standalone command — the output would expose the token in the conversation. Always use it **inline** within curl commands so the token flows through the shell but is never visible:
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
   ```bash
   # CORRECT — token is inline, never shown:
   curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
 
   # WRONG — token value would appear in output:
   qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
   echo $(qovery auth token --print)
   export TOKEN=$(qovery auth token --print)
   ```

--- a/scripts/sync-shared.sh
+++ b/scripts/sync-shared.sh
@@ -11,8 +11,8 @@ cd "$REPO_ROOT"
 # Mapping: <source-under-_shared>  =>  <skill1> <skill2> ...
 # Each line: SRC | SKILL_LIST (space-separated)
 SYNC_MAP=$(cat <<'EOF'
-console-url-detection.md | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform
-auth.md                  | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform
+console-url-detection.md | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-policy-token
+auth.md                  | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-policy-token
 pricing/aws.md           | qovery-optimize
 pricing/gcp.md           | qovery-optimize
 pricing/azure.md         | qovery-optimize


### PR DESCRIPTION
## Summary

Adds a new skill, **`qovery-policy-token`**, that creates a scoped, least-privilege Qovery **API Policy Token** from a plain-English intent — authors the OPA/Rego policy, tests it locally with OPA and live against the API, creates the token, and verifies it allows exactly what the user wants and denies everything else.

An API Policy Token is authorized by a Rego policy evaluated per request (via OPA), instead of an RBAC role — so it can express constraints a role cannot ("read one env, deploy one service, never delete"). Docs: https://www.qovery.com/docs/configuration/organization/api-policy-token

## Workflow (6 phases)

1. **Intent + IDs** — capture allow-list/deny-list, resolve real resource UUIDs (MCP → CLI → API), never guess
2. **Author Rego** — least-privilege `default allow := false` policy, explained rule-by-rule, confirmed with the user
3. **Local pre-flight** — build an allow/deny matrix, run `opa-preflight.sh`, iterate until green **before** creating anything (policies are immutable)
4. **Create** — `POST .../policyApiToken` only after sign-off; capture the one-time secret without echoing it
5. **Live verify** — deny cases probed for real (safe: `401` at auth, never executes), allow reads probed live, destructive allows verified statically and never auto-run
6. **Deliver & lifecycle** — hand over once, immutability, list/revoke, audit attribution

## What's included

- `qovery-policy-token/SKILL.md` (176 lines), slash command, 6 reference phase files
- 4 policy templates (read-only-env, deploy-only, modify-one-service-never-delete, body-constrained-env-var), `test-matrix.example.json`
- 3 scripts: `opa-preflight.sh`, `create-policy-token.sh` (never echoes the secret), `live-verify.sh`
- Wired into `install.sh`, `local-install.sh`, `scripts/sync-shared.sh` (+ synced `auth.md`/`console-url-detection.md`), `README.md`, `qovery` router, and `evals/qovery-policy-token.json` (3 scenarios)

## Test plan

- [x] Downloaded **OPA 1.19.1** (Qovery's version) and ran `opa-preflight.sh` end-to-end: good policy passes **5/5**; over-broad policy correctly caught (`exit 1`, deny case flips to FAIL); `package`-line policy rejected (`exit 2`)
- [x] Validated create-script `jq --rawfile` body encoding (with/without description and expiry)
- [x] All 4 `.rego` templates compile; all 3 shell scripts pass `bash -n`
- [x] API endpoints/fields/error codes cross-checked against official docs (`opa_policy`, `token`, `id`, `expires_at`, `400/403/409`)
- [x] `local-install.sh` smoke test links the skill to all locations
- [x] CLAUDE.md invariants: SKILL.md ≤500 lines, internal links resolve, no anti-patterns, User-Agent on every `api.qovery.com` curl, 3rd-person `Use when` description (480 chars)

## Reviewer notes

- **Safe-by-design live testing** was a deliberate choice: only DENY cases and non-destructive ALLOW reads run live; destructive ALLOW actions are proven statically via OPA and require explicit `--run-destructive` opt-in.
- Policies are immutable (no update endpoint) — the flow confirms the policy before creation and documents delete+recreate to change one.
- The returned token is a secret shown once; `create-policy-token.sh` writes it to a gitignored env file and never prints it, per `_shared/auth.md` rules.