### PR TITLE
feat(signup): add qovery-signup skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ AI agent skills for deploying and troubleshooting applications on Kubernetes usi
 | **qovery-preview** | Create preview environments from PRs — detects/creates blueprint environments, clones for each PR, switches branches, configures auto-shutdown (stop/delete/recycle), provides cleanup. Includes `/qovery-preview` slash command |
 | **qovery-terraform** | Generate Terraform manifests from an existing Qovery setup — reads config from API, generates HCL (qovery/qovery provider), imports resources into state, validates in test clone. Supports single or multiple environments. Safe: never applies to original without confirmation |
 | **qovery-policy-token** | Create a scoped, least-privilege API Policy Token — turns your intent into an OPA/Rego policy, tests it locally with OPA and live against the API, creates the token, and verifies it allows exactly what you want and denies everything else. Includes `/qovery-policy-token` slash command |
+| **qovery-signup** | Sign up from scratch — checks/installs the Qovery CLI, authenticates via `qovery auth --headless` (first login creates the account), and creates your first organization, then hands off to qovery-onboard. Never handles raw tokens. Includes `/qovery-signup` slash command |
 
 > **Looking for Remote Development Environments (RDEs)?** RDEs are now managed directly via [rde.qovery.com](https://rde.qovery.com). See the [RDE documentation](https://www.qovery.com/docs/getting-started/quickstart/remote-dev-environments) to get started.
 
@@ -228,6 +229,13 @@ The onboard skill acts as your personal cloud architect. The deploy skill handle
 - _"Lock a token down to one service"_
 - `/qovery-policy-token` (slash command)
 
+**Prompts that trigger qovery-signup:**
+- _"I'm new to Qovery, help me sign up"_
+- _"Create a Qovery account and log me in"_
+- _"Set up the Qovery CLI and authenticate"_
+- _"Create a new Qovery organization from scratch"_
+- `/qovery-signup` (slash command)
+
 ## Slash Commands
 
 Each skill includes a slash command for quick invocation. Type `/` followed by the command name in your AI tool's chat:
@@ -243,6 +251,7 @@ Each skill includes a slash command for quick invocation. Type `/` followed by t
 | `/qovery-preview` | Create a preview environment for a PR | `/qovery-preview` or `/qovery-preview PR-123` |
 | `/qovery-terraform` | Generate Terraform from existing Qovery setup | `/qovery-terraform` or `/qovery-terraform https://console.qovery.com/...` |
 | `/qovery-policy-token` | Create and verify a scoped API Policy Token | `/qovery-policy-token` or `/qovery-policy-token read-only on staging, can deploy the api service` |
+| `/qovery-signup` | Sign up and create your first organization | `/qovery-signup` or `/qovery-signup org="Acme" plan=USER_2025` |
 
 Commands are installed automatically by the install script. They accept optional arguments (service name, environment name, Console URL) and auto-detect context from your git workspace.
 

--- a/evals/qovery-signup.json
+++ b/evals/qovery-signup.json
@@ -37,6 +37,18 @@
   },
   {
     "skills": ["qovery-signup"],
+    "query": "When someone signs up through this skill, make sure it's tracked in our funnel like the console does.",
+    "files": [],
+    "expected_behavior": [
+      "After account + org creation, records the sign-up by firing `POST /admin/userSignUp` via `qovery api` (CLI auth), mapping the use case to qovery_usage and the org to company_name, with identity auto-read from `qovery api account`",
+      "Also sends the lead to the HubSpot funnel via the Cargo ingest endpoint, tagged signup_source='CLI' (or 'AI-Agent') so it's distinguishable from web ('Console') sign-ups",
+      "Reads the Cargo ingest token only from the QOVERY_CARGO_INGEST_TOKEN env var (never hardcoded or printed); skips the Cargo step gracefully if it's unset",
+      "Treats tracking as best-effort and non-blocking — a tracking failure never breaks the sign-up — and only sends fields the user actually provided (no invented PII)",
+      "Notes that browser-only HubSpot/GTM analytics and UTM attribution cannot be replicated from a terminal, and offers `--dry-run` via record-signup.sh to preview payloads"
+    ]
+  },
+  {
+    "skills": ["qovery-signup"],
     "query": "How does authentication work — I don't want to paste any API tokens into the chat.",
     "files": [],
     "expected_behavior": [

--- a/evals/qovery-signup.json
+++ b/evals/qovery-signup.json
@@ -1,0 +1,38 @@
+[
+  {
+    "skills": ["qovery-signup"],
+    "query": "I'm brand new to Qovery — help me sign up and get an organization set up.",
+    "files": [],
+    "expected_behavior": [
+      "Checks whether the Qovery CLI is installed (command -v qovery / qovery version) and installs it per the user's OS if missing (brew on macOS, scoop on Windows, release binary on Linux)",
+      "Explains that the first login creates the account, and has the user run `qovery auth --headless` (interactive, in Claude Code via `! qovery auth --headless`) to complete OAuth in a browser — never asking for or printing a raw token",
+      "Verifies authentication with `qovery api organization` (JSON = signed in; the 'access token is invalid or expired' message = re-run auth)",
+      "Confirms an organization name and plan (defaulting to USER_2025, noting FREE/PROFESSIONAL are deprecated) before creating it via `qovery api organization --field name=... --field plan=...`",
+      "Sets the CLI context, warns about the NO_CREDIT_CARD deployment restriction (offers `qovery demo up` as a no-card option), and hands off to qovery-onboard"
+    ]
+  },
+  {
+    "skills": ["qovery-signup"],
+    "query": "Create a new Qovery organization called Acme on the team plan.",
+    "files": [],
+    "expected_behavior": [
+      "Ensures the CLI is installed and the user is authenticated first (runs qovery auth --headless if `qovery api organization` returns the invalid/expired-token error)",
+      "Maps 'team plan' to the current plan value TEAM_2025 and confirms name + plan with the user before creating",
+      "Creates the org with `qovery api organization --field name=Acme --field plan=TEAM_2025` (using the CLI's stored credentials, not a manually supplied token) and captures the returned id",
+      "Runs `qovery context set` so the CLI targets the new organization",
+      "Surfaces the credit-card requirement for managed clusters/deployments and points to qovery-onboard for cluster + environment setup"
+    ]
+  },
+  {
+    "skills": ["qovery-signup"],
+    "query": "How does authentication work — I don't want to paste any API tokens into the chat.",
+    "files": [],
+    "expected_behavior": [
+      "Explains that authentication is delegated to the Qovery CLI's own credential store: after `qovery auth --headless`, every `qovery`/`qovery api` call authenticates internally with no token in the shell or conversation",
+      "Notes that `qovery auth --headless` is interactive (prints a URL the user opens in a browser) and that the agent cannot complete the browser step",
+      "States it will never ask for, echo, or store a raw token, and that if a token is ever needed inline it uses `qovery auth token --print` within a command, per auth.md",
+      "Mentions the CI/non-interactive alternative: setting QOVERY_CLI_ACCESS_TOKEN (or Q_CLI_ACCESS_TOKEN), generated via `qovery token` and stored in a secret manager",
+      "Does not request credentials from the user in the chat at any point"
+    ]
+  }
+]

--- a/evals/qovery-signup.json
+++ b/evals/qovery-signup.json
@@ -25,6 +25,18 @@
   },
   {
     "skills": ["qovery-signup"],
+    "query": "Sign me up and set up an org for my company at https://acme.com — we want to run preview environments for our PRs.",
+    "files": [],
+    "expected_behavior": [
+      "Ensures CLI + auth first, then interviews: confirms the organization name, records the website (https://acme.com) and the use case (PR preview environments), and the plan",
+      "Runs enrich-from-website.sh on acme.com to derive a candidate description, logo_url, and icon_url (with Clearbit/Google-favicon fallbacks), and shows them to the user to confirm before setting anything",
+      "Creates the organization via `qovery api organization --input -` including name, plan, website_url, description, logo_url, and icon_url",
+      "Configures for the use case without needing billing — e.g. creates a first project (POST organization/{id}/project) named for PR previews — and notes clusters/environments are handled by qovery-onboard",
+      "Hands off to qovery-onboard with a brief (org id, use case = PR previews, website, billing status), and mentions qovery-preview as the eventual skill for per-PR environments"
+    ]
+  },
+  {
+    "skills": ["qovery-signup"],
     "query": "How does authentication work — I don't want to paste any API tokens into the chat.",
     "files": [],
     "expected_behavior": [

--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # https://github.com/Qovery/qovery-skills
 # ============================================================
 
-SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform" "qovery-policy-token")
+SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform" "qovery-policy-token" "qovery-signup")
 TARBALL_URL="https://codeload.github.com/Qovery/qovery-skills/tar.gz/refs/heads/main"
 
 # Colors (if terminal supports them)
@@ -253,6 +253,7 @@ echo -e "  ${YELLOW}qovery-speedup${NC}       — Speed up deployments and build
 echo -e "  ${YELLOW}qovery-preview${NC}       — Create preview environments from PRs"
 echo -e "  ${YELLOW}qovery-terraform${NC}     — Terraformize existing Qovery setups"
 echo -e "  ${YELLOW}qovery-policy-token${NC}  — Create and verify scoped API policy tokens"
+echo -e "  ${YELLOW}qovery-signup${NC}        — Sign up and create your first organization"
 echo ""
 echo -e "${BOLD}Compatible with:${NC}"
 echo "  Claude Code, OpenCode, Cursor, VS Code Copilot, Gemini CLI,"

--- a/local-install.sh
+++ b/local-install.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # https://github.com/Qovery/qovery-skills
 # ============================================================
 
-SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform" "qovery-policy-token")
+SKILLS=("qovery" "qovery-onboard" "qovery-deploy" "qovery-troubleshoot" "qovery-optimize" "qovery-speedup" "qovery-preview" "qovery-terraform" "qovery-policy-token" "qovery-signup")
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Colors (if terminal supports them)
@@ -276,6 +276,7 @@ echo -e "  ${YELLOW}qovery-speedup${NC}       — Speed up deployments and build
 echo -e "  ${YELLOW}qovery-preview${NC}       — Create preview environments from PRs"
 echo -e "  ${YELLOW}qovery-terraform${NC}     — Terraformize existing Qovery setups"
 echo -e "  ${YELLOW}qovery-policy-token${NC}  — Create and verify scoped API policy tokens"
+echo -e "  ${YELLOW}qovery-signup${NC}        — Sign up and create your first organization"
 echo ""
 echo -e "${BOLD}Slash commands:${NC} /qovery-<skill> (e.g. /qovery-deploy, /qovery-troubleshoot, /qovery-terraform…)."
 echo ""

--- a/qovery-signup/SKILL.md
+++ b/qovery-signup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qovery-signup
-description: Takes a brand-new user from nothing to a working Qovery account and first organization — checks the Qovery CLI is installed (installs it if missing), signs them in with `qovery auth --headless` (which creates the account on first OAuth login), then creates an organization via the API and sets the CLI context. Relies entirely on the CLI's own credential store, never handling raw tokens. Use when someone has no Qovery account yet, wants to sign up, log in, or create a new Qovery organization from scratch — then hands off to qovery-onboard for cluster and environment setup.
+description: Takes a brand-new user from nothing to a working Qovery account and first organization — checks the Qovery CLI is installed (installs it if missing), signs them in with `qovery auth --headless` (which creates the account on first OAuth login), then creates an organization via the API, enriches it from the company website, records the sign-up for tracking and lead qualification (tagged as a CLI/agent sign-up), and sets the CLI context. Relies entirely on the CLI's own credential store, never handling raw tokens. Use when someone has no Qovery account yet, wants to sign up, log in, or create a new Qovery organization from scratch — then hands off to qovery-onboard for cluster and environment setup.
 license: MIT
 compatibility: opencode
 metadata:
@@ -43,6 +43,8 @@ SKILL_NAME="qovery-signup"
 > **There is no `qovery organization` CLI command.** Manage organizations through `qovery api organization …` (which uses the CLI's auth) or the REST API — not a CLI noun.
 >
 > **Set expectations about billing.** A new organization has no credit card, so managed clusters and deployments are blocked (`billing_deployment_restriction: NO_CREDIT_CARD`) until one is added. A local demo cluster (`qovery demo up`) works with no card.
+>
+> **Sign-up tracking is tagged, consented, and best-effort.** Phase 4 records the sign-up in Qovery's pipeline and the HubSpot lead funnel, always tagged `signup_source: "CLI"` / `"AI-Agent"` so it's distinguishable from web sign-ups. Only send data the user gave in the interview — never invent PII. The Cargo/HubSpot token comes from `QOVERY_CARGO_INGEST_TOKEN` (or backend forwarding) and is **never committed or printed**. Tracking must never block or fail the sign-up.
 
 ## When to Use This Skill
 
@@ -63,7 +65,8 @@ Sign up + create an organization:
 - [ ] Phase 1 — CLI setup: detect OS, check `qovery` is installed (install if missing), verify version
 - [ ] Phase 2 — Authenticate: run `qovery auth --headless` (first login creates the account); verify auth
 - [ ] Phase 3 — Interview + create + enrich: ask name, website, use case, plan; create the org; enrich its profile (description, logo, icon) from the website; set context
-- [ ] Phase 4 — Configure + hand off: optional first project for the use case, billing/demo-cluster note, invite team, hand a brief to qovery-onboard
+- [ ] Phase 4 — Record sign-up: fire `POST /admin/userSignUp` + the Cargo/HubSpot lead ingest, tagged `signup_source=CLI` (best-effort, non-blocking)
+- [ ] Phase 5 — Configure + hand off: optional first project for the use case, billing/demo-cluster note, invite team, hand a brief to qovery-onboard
 ```
 
 ## Authentication model (how auth is handled)
@@ -81,7 +84,8 @@ Sign up + create an organization:
 | Phase 1 | [reference/phase1-cli-setup.md](reference/phase1-cli-setup.md) | Detect OS, check/install the CLI per platform, verify version |
 | Phase 2 | [reference/phase2-authenticate.md](reference/phase2-authenticate.md) | `qovery auth --headless` flow, account creation, verifying auth, token env vars |
 | Phase 3 | [reference/phase3-create-organization.md](reference/phase3-create-organization.md) | Interview (name, website, use case, plan); create via `qovery api`; enrich profile (description/logo/icon) from the website; update via PUT; set context; billing restriction |
-| Phase 4 | [reference/phase4-next-steps.md](reference/phase4-next-steps.md) | Configure for the use case (optional first project), add credit card / `qovery demo up`, invite teammates, hand a brief to qovery-onboard |
+| Phase 4 | [reference/phase4-signup-tracking.md](reference/phase4-signup-tracking.md) | Record the sign-up for tracking + lead qualification (mirrors the console): `POST /admin/userSignUp` + Cargo→HubSpot ingest, tagged `signup_source=CLI`; token via env, never committed |
+| Phase 5 | [reference/phase5-next-steps.md](reference/phase5-next-steps.md) | Configure for the use case (optional first project), add credit card / `qovery demo up`, invite teammates, hand a brief to qovery-onboard |
 
 ## Templates
 
@@ -89,6 +93,7 @@ Sign up + create an organization:
 |---|---|
 | [templates/scripts/check-and-install-cli.sh](templates/scripts/check-and-install-cli.sh) | Detect whether the CLI is installed + its version; print the right install command per OS if missing |
 | [templates/scripts/enrich-from-website.sh](templates/scripts/enrich-from-website.sh) | Derive candidate org profile (description, logo_url, icon_url) from a company website, with fallbacks |
+| [templates/scripts/record-signup.sh](templates/scripts/record-signup.sh) | Record the sign-up: `POST /admin/userSignUp` + Cargo/HubSpot lead ingest, tagged `signup_source`; `--dry-run` supported; Cargo token from env only |
 
 ## Quick reference
 
@@ -109,7 +114,10 @@ bash templates/scripts/enrich-from-website.sh example.com
 qovery api organization --field name="My Org" --field plan=USER_2025
 #    …or with the enriched profile via --input (see Phase 3.4)
 
-# 4. Point the CLI at it, then hand off to qovery-onboard
+# 4. Record the sign-up for tracking + lead qualification (tagged CLI; --dry-run to preview)
+COMPANY="My Org" USE_CASE="<use case>" SIGNUP_SOURCE="CLI" bash templates/scripts/record-signup.sh
+
+# 5. Point the CLI at it, then hand off to qovery-onboard
 qovery context set
 
 # Optional: try Qovery locally with no credit card

--- a/qovery-signup/SKILL.md
+++ b/qovery-signup/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: qovery-signup
+description: Takes a brand-new user from nothing to a working Qovery account and first organization — checks the Qovery CLI is installed (installs it if missing), signs them in with `qovery auth --headless` (which creates the account on first OAuth login), then creates an organization via the API and sets the CLI context. Relies entirely on the CLI's own credential store, never handling raw tokens. Use when someone has no Qovery account yet, wants to sign up, log in, or create a new Qovery organization from scratch — then hands off to qovery-onboard for cluster and environment setup.
+license: MIT
+compatibility: opencode
+metadata:
+  audience: new-users
+  workflow: signup-and-org-creation
+---
+
+# Qovery Sign-up Skill
+
+Gets a brand-new user fully onboarded to the point of having an account and an organization: verify (or install) the Qovery CLI → sign in with `qovery auth --headless` (first login **is** the sign-up) → create an organization → set the CLI context → hand off to **qovery-onboard** for clusters and environments.
+
+The whole flow leans on the **Qovery CLI's own credential store** — after `qovery auth`, every call authenticates internally, so no raw tokens ever flow through the shell or this conversation.
+
+## Usage Tracking
+
+**EXECUTE THIS BASH COMMAND after the user is authenticated (Phase 2). Skip it before auth — there is no token yet.**
+
+```bash
+QOVERY_ORG_ID=$(qovery api organization 2>/dev/null | jq -r '.results[0].id' 2>/dev/null)
+SKILL_NAME="qovery-signup"
+[ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+  -H "Authorization: Bearer $(qovery auth token --print 2>/dev/null)" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: QoverySkill/qovery-signup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+```
+
+> **API rule:** every `curl` to `api.qovery.com` MUST carry the `User-Agent` header above. Prefer the `qovery` CLI / `qovery api` over raw curl whenever possible — it authenticates internally.
+
+## CRITICAL RULES
+
+> **Authentication is the CLI's job — not yours.** Never ask for, print, store, or paste raw tokens. The user signs in once with `qovery auth --headless`; after that, `qovery api …` and every `qovery` command use the locally stored credentials. See [reference/auth.md](reference/auth.md).
+>
+> **`qovery auth --headless` is interactive and needs the user's browser.** It prints a URL the user must open and complete (GitHub / GitLab / Google / email). You cannot do the browser step for them. In Claude Code, have the user run `! qovery auth --headless` so the URL appears in-session; then wait for them to confirm they finished.
+>
+> **First login = sign-up.** A brand-new user does not "register" separately — the account is created automatically on the first successful OAuth login. There is no API to create an account.
+>
+> **Confirm the org name and plan before creating.** Organization creation is a real, billable-tier resource. Get explicit confirmation of both. Default individuals to `USER_2025`.
+>
+> **There is no `qovery organization` CLI command.** Manage organizations through `qovery api organization …` (which uses the CLI's auth) or the REST API — not a CLI noun.
+>
+> **Set expectations about billing.** A new organization has no credit card, so managed clusters and deployments are blocked (`billing_deployment_restriction: NO_CREDIT_CARD`) until one is added. A local demo cluster (`qovery demo up`) works with no card.
+
+## When to Use This Skill
+
+Trigger phrases:
+- "I'm new to Qovery, help me sign up"
+- "Create a Qovery account / log me in"
+- "Set up the Qovery CLI and authenticate"
+- "Create a new Qovery organization"
+- "How do I get started with Qovery from scratch?"
+- `/qovery-signup` (slash command)
+
+For setting up clusters, projects, environments, RBAC, and cloud providers **after** an org exists, hand off to **qovery-onboard**. For deploying an app, use **qovery-deploy**.
+
+## Workflow checklist
+
+```
+Sign up + create an organization:
+- [ ] Phase 1 — CLI setup: detect OS, check `qovery` is installed (install if missing), verify version
+- [ ] Phase 2 — Authenticate: run `qovery auth --headless` (first login creates the account); verify auth
+- [ ] Phase 3 — Create organization: confirm name + plan, create via `qovery api organization`, set context
+- [ ] Phase 4 — Next steps: billing/credit-card note, demo cluster option, invite team, hand off to qovery-onboard
+```
+
+## Authentication model (how auth is handled)
+
+1. **Install** the CLI (Phase 1) — `brew install qovery-cli` (macOS), `scoop install qovery-cli` (Windows), or a release binary (Linux). `qovery upgrade` updates it.
+2. **`qovery auth --headless`** (Phase 2) prints a URL. The user opens it, signs in / signs up via OAuth, and the CLI saves credentials locally. Interactive `qovery auth` (no flag) opens a browser automatically when the machine has one.
+3. **Everything after that uses the stored credentials** — `qovery api …`, `qovery project …`, etc. — so you never touch a token. If a call returns `access token is invalid or expired. Sign in using 'qovery auth'…`, the session lapsed; re-run Phase 2.
+4. **CI / non-interactive** only: the user may set `QOVERY_CLI_ACCESS_TOKEN` (or `Q_CLI_ACCESS_TOKEN`) in their environment instead of interactive login. Generate one with `qovery token`. Never print it.
+
+## Reference materials (load on demand)
+
+| Phase | File | Purpose |
+|---|---|---|
+| Auth | [reference/auth.md](reference/auth.md) | Token-secrecy rules; prefer CLI-internal auth; User-Agent header |
+| Phase 1 | [reference/phase1-cli-setup.md](reference/phase1-cli-setup.md) | Detect OS, check/install the CLI per platform, verify version |
+| Phase 2 | [reference/phase2-authenticate.md](reference/phase2-authenticate.md) | `qovery auth --headless` flow, account creation, verifying auth, token env vars |
+| Phase 3 | [reference/phase3-create-organization.md](reference/phase3-create-organization.md) | Plan choice (2025 plans), create via `qovery api`, capture id, set context, billing restriction |
+| Phase 4 | [reference/phase4-next-steps.md](reference/phase4-next-steps.md) | Add credit card, `qovery demo up`, invite teammates, hand off to qovery-onboard |
+
+## Templates
+
+| Template | Use |
+|---|---|
+| [templates/scripts/check-and-install-cli.sh](templates/scripts/check-and-install-cli.sh) | Detect whether the CLI is installed + its version; print the right install command per OS if missing |
+
+## Quick reference
+
+```bash
+# 1. Install (macOS shown; see Phase 1 for Windows/Linux) and verify
+brew install qovery-cli
+qovery version
+
+# 2. Sign up / log in (interactive — user completes the URL in a browser). In Claude Code:
+#    ! qovery auth --headless
+#    Verify it worked (should return JSON, not an auth error):
+qovery api organization
+
+# 3. Create an organization (uses the CLI's stored auth; no token handling)
+qovery api organization --field name="My Org" --field plan=USER_2025
+
+# 4. Point the CLI at it, then hand off to qovery-onboard
+qovery context set
+
+# Optional: try Qovery locally with no credit card
+qovery demo up
+```
+
+## Organization plans
+
+Pass one of these as `plan` when creating (2025 plans are current; `FREE` / `PROFESSIONAL` / `BUSINESS` are deprecated):
+
+| Plan | For |
+|---|---|
+| `USER_2025` | Individuals / getting started (default) |
+| `TEAM_2025` | Small teams |
+| `BUSINESS_2025` | Growing companies |
+| `ENTERPRISE_2025` | Large orgs (SSO, advanced controls) |
+
+> Always verify current plan names and pricing at <https://www.qovery.com/pricing> — plans change over time.
+
+## Reference links
+
+- **Create organization API**: <https://www.qovery.com/docs/api-reference/organization-main-calls/create-an-organization>
+- **Qovery CLI**: <https://www.qovery.com/docs/cli/overview>
+- **Qovery CLI (GitHub / install)**: <https://github.com/Qovery/qovery-cli>
+- **Pricing & plans**: <https://www.qovery.com/pricing>
+- **Qovery Console**: <https://console.qovery.com>

--- a/qovery-signup/SKILL.md
+++ b/qovery-signup/SKILL.md
@@ -62,8 +62,8 @@ For setting up clusters, projects, environments, RBAC, and cloud providers **aft
 Sign up + create an organization:
 - [ ] Phase 1 — CLI setup: detect OS, check `qovery` is installed (install if missing), verify version
 - [ ] Phase 2 — Authenticate: run `qovery auth --headless` (first login creates the account); verify auth
-- [ ] Phase 3 — Create organization: confirm name + plan, create via `qovery api organization`, set context
-- [ ] Phase 4 — Next steps: billing/credit-card note, demo cluster option, invite team, hand off to qovery-onboard
+- [ ] Phase 3 — Interview + create + enrich: ask name, website, use case, plan; create the org; enrich its profile (description, logo, icon) from the website; set context
+- [ ] Phase 4 — Configure + hand off: optional first project for the use case, billing/demo-cluster note, invite team, hand a brief to qovery-onboard
 ```
 
 ## Authentication model (how auth is handled)
@@ -80,14 +80,15 @@ Sign up + create an organization:
 | Auth | [reference/auth.md](reference/auth.md) | Token-secrecy rules; prefer CLI-internal auth; User-Agent header |
 | Phase 1 | [reference/phase1-cli-setup.md](reference/phase1-cli-setup.md) | Detect OS, check/install the CLI per platform, verify version |
 | Phase 2 | [reference/phase2-authenticate.md](reference/phase2-authenticate.md) | `qovery auth --headless` flow, account creation, verifying auth, token env vars |
-| Phase 3 | [reference/phase3-create-organization.md](reference/phase3-create-organization.md) | Plan choice (2025 plans), create via `qovery api`, capture id, set context, billing restriction |
-| Phase 4 | [reference/phase4-next-steps.md](reference/phase4-next-steps.md) | Add credit card, `qovery demo up`, invite teammates, hand off to qovery-onboard |
+| Phase 3 | [reference/phase3-create-organization.md](reference/phase3-create-organization.md) | Interview (name, website, use case, plan); create via `qovery api`; enrich profile (description/logo/icon) from the website; update via PUT; set context; billing restriction |
+| Phase 4 | [reference/phase4-next-steps.md](reference/phase4-next-steps.md) | Configure for the use case (optional first project), add credit card / `qovery demo up`, invite teammates, hand a brief to qovery-onboard |
 
 ## Templates
 
 | Template | Use |
 |---|---|
 | [templates/scripts/check-and-install-cli.sh](templates/scripts/check-and-install-cli.sh) | Detect whether the CLI is installed + its version; print the right install command per OS if missing |
+| [templates/scripts/enrich-from-website.sh](templates/scripts/enrich-from-website.sh) | Derive candidate org profile (description, logo_url, icon_url) from a company website, with fallbacks |
 
 ## Quick reference
 
@@ -101,8 +102,12 @@ qovery version
 #    Verify it worked (should return JSON, not an auth error):
 qovery api organization
 
-# 3. Create an organization (uses the CLI's stored auth; no token handling)
+# 3. (optional) Derive description/logo/icon from the company website, confirm with the user
+bash templates/scripts/enrich-from-website.sh example.com
+
+# 3b. Create an organization (uses the CLI's stored auth; no token handling)
 qovery api organization --field name="My Org" --field plan=USER_2025
+#    …or with the enriched profile via --input (see Phase 3.4)
 
 # 4. Point the CLI at it, then hand off to qovery-onboard
 qovery context set

--- a/qovery-signup/commands/qovery-signup.md
+++ b/qovery-signup/commands/qovery-signup.md
@@ -1,0 +1,17 @@
+---
+description: Sign up for Qovery and create your first organization
+---
+
+Get started with Qovery from scratch: install the CLI if needed, authenticate, and create your first organization.
+
+If arguments are provided, use them as context:
+- `$ARGUMENTS` — a desired organization name and/or plan (e.g. "org=Acme plan=USER_2025")
+
+Follow the qovery-signup skill to:
+1. Check the Qovery CLI is installed (install it if missing) and verify the version
+2. Sign in with `qovery auth --headless` — the first login creates the account (no separate registration)
+3. Confirm an organization name + plan, then create it via `qovery api organization`
+4. Set the CLI context and cover next steps (billing, demo cluster, inviting the team)
+5. Hand off to the qovery-onboard skill for cluster and environment setup
+
+CRITICAL: Never ask for, print, or store raw tokens — authentication is handled by the CLI's own credential store after `qovery auth`. Confirm the org name and plan before creating.

--- a/qovery-signup/reference/auth.md
+++ b/qovery-signup/reference/auth.md
@@ -1,0 +1,95 @@
+# Qovery Authentication
+
+## Security — Token Handling Rules
+
+**CRITICAL: NEVER display, log, print, or capture Qovery token values.**
+
+- NEVER run `qovery auth token --print` (or `qovery auth token --json`) as a standalone command — the output dumps the token into the conversation. `--json` emits the raw access token too, so always pipe it through `jq` to extract only the field you need. Use `--print` **inline** within curl commands so the token flows through the shell but is never visible:
+  ```bash
+  # CORRECT — token is inline, never shown:
+  curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/...
+  # CORRECT — check auth without printing the token (jq extracts one field only):
+  qovery auth token --json 2>/dev/null | jq -r '.token_type'
+
+  # WRONG — token value would appear in output:
+  qovery auth token --print
+  qovery auth token --json            # dumps the full access_token
+  echo $(qovery auth token --print)
+  export TOKEN=$(qovery auth token --print)
+  ```
+- NEVER run `echo $QOVERY_API_TOKEN`, `echo $QOVERY_CLI_ACCESS_TOKEN`, or any command that prints token values to stdout
+- NEVER include actual token values in responses to the user — use `***` or `(hidden)` if you need to reference them
+- NEVER store tokens in shell variables via command substitution that the agent can read — always use them inline
+- NEVER include real token values in generated code, scripts, or config files — use env var references like `$QOVERY_API_TOKEN`
+- Prefer the `qovery` CLI directly (e.g., `qovery environment list`, `qovery log --service "name"`) over `curl` with tokens when possible — the CLI authenticates internally without exposing tokens
+- When running `qovery token create`, the command outputs the new token. Do NOT display it. Pipe it directly into a secure storage or env var file that is NOT read by the agent.
+
+## Qovery API Request Rules — User-Agent
+
+**Every `curl` request to the Qovery API (`api.qovery.com`) MUST include a User-Agent header identifying the skill and version.**
+
+The version is read from `_version.txt` (written at install time by `install.sh`). When executing curl commands, the agent MUST add this header:
+
+```bash
+# Read the version (do this once per session):
+QOVERY_SKILLS_VERSION=$(cat _version.txt 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+# Add to every curl command:
+-H "User-Agent: QoverySkill/auth (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)"
+```
+
+Full example:
+```bash
+curl -s \
+  -H "Authorization: Token $QOVERY_API_TOKEN" \
+  -H "User-Agent: QoverySkill/auth (version:$QOVERY_SKILLS_VERSION; https://github.com/Qovery/qovery-skills)" \
+  https://api.qovery.com/organization
+```
+
+This applies to ALL curl commands targeting `api.qovery.com` — even when reference file examples don't explicitly show the User-Agent header. The agent MUST add it to every request it executes. Use `auth` as the context for the shared auth flow. When executing curl commands from a specific skill's reference files, use that skill's name instead (e.g., `qovery-deploy`, `qovery-troubleshoot`).
+
+---
+
+## 1. Existing API token in environment
+
+```bash
+# Check if a token is available (without printing it):
+test -n "${QOVERY_API_TOKEN:-${QOVERY_CLI_ACCESS_TOKEN:-}}" && echo "Token found" || echo "No token"
+```
+
+If a token is found, use it directly in curl commands as `Authorization: Token $QOVERY_API_TOKEN`. The env var is expanded by the shell at execution time — the agent never sees the actual value.
+
+## 2. CLI already authenticated (`qovery auth token`)
+
+```bash
+# Check if the CLI is authenticated (without printing the token):
+qovery auth token --json 2>/dev/null | jq -r '.type' && echo "CLI authenticated" || echo "CLI not authenticated"
+```
+
+If the CLI is authenticated, use `qovery auth token --print` **inline** within curl commands:
+
+```bash
+# Token flows through the shell but is never visible to the agent:
+curl -s -H "Authorization: Bearer $(qovery auth token --print)" https://api.qovery.com/organization
+```
+
+Or generate a named API token for longer-running scripts. The token must be stored securely — do NOT display the output:
+
+```bash
+# Create the token and store it directly in .env (not displayed):
+qovery token create --name "skill-$(date +%Y%m%d-%H%M%S)" --duration 24h > .qovery-token.tmp
+# The user should manually export it or add it to their secure env config
+echo "API token created. Add QOVERY_API_TOKEN to your environment from .qovery-token.tmp"
+```
+
+## 3. Interactive login
+
+If neither of the above works, prompt the user:
+
+```bash
+qovery auth                      # interactive browser login
+# OR for headless:
+# The user sets QOVERY_CLI_ACCESS_TOKEN in their environment (not via the agent)
+```
+
+After login, fall through to step 2 to obtain a token.

--- a/qovery-signup/reference/phase1-cli-setup.md
+++ b/qovery-signup/reference/phase1-cli-setup.md
@@ -1,0 +1,43 @@
+# Phase 1 — Install and Verify the Qovery CLI
+
+The whole sign-up flow runs through the Qovery CLI, so make sure it is present and current before anything else.
+
+## 1.1 Check whether it is already installed
+
+```bash
+command -v qovery >/dev/null 2>&1 && qovery version || echo "Qovery CLI not found"
+```
+
+Run `templates/scripts/check-and-install-cli.sh` to do this and print the right install command for the user's OS when it is missing.
+
+- **Installed** → note the version and go to Phase 2. Offer `qovery upgrade` if it looks old.
+- **Not installed** → install it (§1.2).
+
+## 1.2 Install per platform
+
+| OS / manager | Command |
+|---|---|
+| macOS (Homebrew) | `brew install qovery-cli` |
+| Windows (Scoop) | `scoop install qovery-cli` |
+| Arch Linux (yay) | `yay qovery-cli` |
+| Any (release binary) | Download the latest from <https://github.com/Qovery/qovery-cli/releases>, unpack, and move `qovery` onto your `PATH` (e.g. `/usr/local/bin`) |
+| Docker | `public.ecr.aws/r3m4q3r9/qovery-cli` |
+
+Notes:
+- On macOS without Homebrew, either install Homebrew first or use the release binary.
+- Prefer letting the user run the install command themselves if it needs elevated permissions (e.g. writing to `/usr/local/bin` or `brew` on a locked-down machine). In Claude Code they can run `! brew install qovery-cli`.
+- Do **not** auto-run `sudo` installs without asking.
+
+## 1.3 Verify
+
+```bash
+qovery version
+```
+
+A version string (e.g. `Info: 1.166.x`) confirms it is ready. To update later:
+
+```bash
+qovery upgrade
+```
+
+Once `qovery version` works, continue to Phase 2 (authenticate).

--- a/qovery-signup/reference/phase2-authenticate.md
+++ b/qovery-signup/reference/phase2-authenticate.md
@@ -1,0 +1,38 @@
+# Phase 2 — Authenticate (sign up = first login)
+
+A brand-new user does not register separately. The **first successful login creates the account** through Qovery's OAuth flow (GitHub, GitLab, Google, or email). There is no API to create an account — authentication is always done through the CLI (or Console).
+
+## 2.1 Run the headless login
+
+```bash
+qovery auth --headless
+```
+
+`--headless` prints a **URL** and waits. The user opens that URL in a browser, signs in / signs up with their provider, and the CLI stores the credentials locally. (Plain `qovery auth`, without the flag, opens a browser automatically when the machine has one — use `--headless` for remote shells, containers, or anywhere the agent is driving a non-GUI terminal.)
+
+**This step is interactive and needs the user's browser — you cannot complete it for them.** In Claude Code, ask the user to run it so the URL lands in the session and they can act on it:
+
+```
+! qovery auth --headless
+```
+
+Then wait for the user to confirm they finished the browser step before continuing. Do not try to scrape or submit the OAuth flow yourself.
+
+## 2.2 Verify authentication
+
+Confirm the stored credentials work with any authenticated read — `qovery api organization` returns JSON when signed in:
+
+```bash
+qovery api organization
+```
+
+- **JSON (a `results` array, possibly empty)** → authenticated. Continue to Phase 3.
+- **`access token is invalid or expired. Sign in using 'qovery auth' or 'qovery auth --headless' command.`** → not signed in (or the session lapsed). Re-run §2.1.
+
+## 2.3 How authentication is managed from here on
+
+- After login, **every** `qovery` command and `qovery api …` call uses the locally stored credentials. You never handle, print, or paste a token. This is the safe path and it satisfies the token-secrecy rules in [auth.md](auth.md).
+- If you ever need the token inline (rare), use `qovery auth token --print` **inside** a command — never as a standalone that echoes it (see [auth.md](auth.md)).
+- **CI / non-interactive environments**: instead of interactive login, the user can set `QOVERY_CLI_ACCESS_TOKEN` (or `Q_CLI_ACCESS_TOKEN`) in their environment. Generate a token with `qovery token` and store it in their secret manager — do not print it.
+
+Once `qovery api organization` returns JSON, continue to Phase 3.

--- a/qovery-signup/reference/phase3-create-organization.md
+++ b/qovery-signup/reference/phase3-create-organization.md
@@ -1,0 +1,59 @@
+# Phase 3 — Create the Organization
+
+An organization is the top-level container for everything in Qovery (projects, environments, clusters, members). Create one only after the user confirms the **name** and **plan**.
+
+## 3.1 Choose a name and plan
+
+Ask the user for an organization name (case-insensitive) and which plan to start on. The current plans are the **2025** tiers — `FREE`, `PROFESSIONAL`, and `BUSINESS` are deprecated:
+
+| Plan value | For |
+|---|---|
+| `USER_2025` | Individuals / getting started (default) |
+| `TEAM_2025` | Small teams |
+| `BUSINESS_2025` | Growing companies |
+| `ENTERPRISE_2025` | Large orgs (SSO, advanced controls) |
+
+Confirm both before creating — verify current names/pricing at <https://www.qovery.com/pricing> if unsure.
+
+## 3.2 Create it (via the CLI's authenticated API access)
+
+There is no `qovery organization` command; use `qovery api`, which reuses the stored credentials from Phase 2 — no token handling:
+
+```bash
+qovery api organization --field name="My Org" --field plan=USER_2025
+```
+
+The response is the new `Organization` object — capture its `id`:
+
+```bash
+NEW_ORG_ID=$(qovery api organization --field name="My Org" --field plan=USER_2025 | jq -r '.id')
+echo "Created organization: $NEW_ORG_ID"
+```
+
+Optional fields (repeat `--field`): `description`, `website_url`, `admin_emails` (invite teammates at creation).
+
+**Equivalent raw API** (only if not using the CLI — needs an owner token and the standard headers from [auth.md](auth.md)):
+
+```bash
+qovery api organization --input - <<'JSON'
+{ "name": "My Org", "plan": "USER_2025" }
+JSON
+```
+
+Errors:
+- `access token is invalid or expired…` → not authenticated; go back to Phase 2.
+- `400` → check the `plan` value is one of the current plans above and `name` is present.
+
+## 3.3 Point the CLI at the new organization
+
+```bash
+qovery context set
+```
+
+Follow the prompts to select the new organization (and later a project/environment). This sets the default context so subsequent commands target the right org.
+
+## 3.4 Billing restriction on brand-new orgs (set expectations)
+
+A newly created organization has **no credit card**, so it carries `billing_deployment_restriction: NO_CREDIT_CARD`: managed (cloud) cluster creation and deployments are blocked until a card is added in the Console (**Settings → Billing**). A local **demo cluster works without a card** (see Phase 4). Tell the user this now so the restriction later isn't a surprise.
+
+Continue to Phase 4 for next steps and the hand-off to qovery-onboard.

--- a/qovery-signup/reference/phase3-create-organization.md
+++ b/qovery-signup/reference/phase3-create-organization.md
@@ -1,10 +1,21 @@
-# Phase 3 — Create the Organization
+# Phase 3 — Interview, Create, and Enrich the Organization
 
-An organization is the top-level container for everything in Qovery (projects, environments, clusters, members). Create one only after the user confirms the **name** and **plan**.
+An organization is the top-level container for everything in Qovery (projects, environments, clusters, members). Interview the user, create the org, and enrich its profile (description + logo + icon) from their website — then let Phase 4 configure Qovery for their use case.
 
-## 3.1 Choose a name and plan
+## 3.1 Guided interview
 
-Ask the user for an organization name (case-insensitive) and which plan to start on. The current plans are the **2025** tiers — `FREE`, `PROFESSIONAL`, and `BUSINESS` are deprecated:
+Ask the user (one at a time, plain menus where it helps):
+
+1. **Organization name** — what to call it (case-insensitive). Usually the company or team name.
+2. **Website** — the company/product URL. Used to auto-fill the description, logo, and icon (§3.3) and stored as `website_url`. Optional but recommended; skip enrichment if they have none.
+3. **Use case** — what they want to do with Qovery: e.g. "deploy a Node.js API + Postgres to AWS", "preview environments for PRs", "run internal tools", "migrate off Heroku". This drives how Phase 4 configures Qovery and what you hand to **qovery-onboard**.
+4. **Plan** — see §3.2. Default individuals to `USER_2025`.
+
+Confirm the name and plan before creating (org creation is a real, billable-tier resource).
+
+## 3.2 Plans
+
+Current plans are the **2025** tiers — `FREE`, `PROFESSIONAL`, and `BUSINESS` are deprecated:
 
 | Plan value | For |
 |---|---|
@@ -13,47 +24,68 @@ Ask the user for an organization name (case-insensitive) and which plan to start
 | `BUSINESS_2025` | Growing companies |
 | `ENTERPRISE_2025` | Large orgs (SSO, advanced controls) |
 
-Confirm both before creating — verify current names/pricing at <https://www.qovery.com/pricing> if unsure.
+Verify current names/pricing at <https://www.qovery.com/pricing> if unsure.
 
-## 3.2 Create it (via the CLI's authenticated API access)
+## 3.3 Enrich from the website (description, logo, icon)
 
-There is no `qovery organization` command; use `qovery api`, which reuses the stored credentials from Phase 2 — no token handling:
+If the user gave a website, derive profile fields from it:
 
 ```bash
-qovery api organization --field name="My Org" --field plan=USER_2025
+bash templates/scripts/enrich-from-website.sh <website-url>
 ```
 
-The response is the new `Organization` object — capture its `id`:
+It returns candidate `description`, `logo_url`, `icon_url` (plus a `candidates` list with alternatives — the site's own og:image/favicon **and** deterministic fallbacks `https://logo.clearbit.com/<domain>` for the logo and Google's favicon service for the icon). It decodes HTML entities so the URLs are valid.
+
+**Show the candidates to the user and let them confirm or swap** (og:image is usually a wide social card; Clearbit is usually a cleaner square logo). If extraction found nothing useful, write a one-line description yourself from what you know about the company and confirm it. Never set a field the user hasn't seen.
+
+## 3.4 Create the organization (with the enriched profile)
+
+There is no `qovery organization` command; use `qovery api`, which reuses the stored credentials from Phase 2 — no token handling. Pass the whole profile via `--input` (handles descriptions with spaces/quotes cleanly):
 
 ```bash
-NEW_ORG_ID=$(qovery api organization --field name="My Org" --field plan=USER_2025 | jq -r '.id')
+NEW_ORG_ID=$(qovery api organization --input - <<JSON | jq -r '.id'
+{
+  "name": "My Org",
+  "plan": "USER_2025",
+  "website_url": "https://example.com",
+  "description": "One-line company description",
+  "logo_url": "https://logo.clearbit.com/example.com",
+  "icon_url": "https://www.google.com/s2/favicons?domain=example.com&sz=128"
+}
+JSON
+)
 echo "Created organization: $NEW_ORG_ID"
 ```
 
-Optional fields (repeat `--field`): `description`, `website_url`, `admin_emails` (invite teammates at creation).
+For a bare org (no website), the short form is enough: `qovery api organization --field name="My Org" --field plan=USER_2025`.
 
-**Equivalent raw API** (only if not using the CLI — needs an owner token and the standard headers from [auth.md](auth.md)):
+Errors: `access token is invalid or expired…` → re-do Phase 2; `400` → check `plan` is a current value and `name` is present; `409` → the name is taken.
+
+## 3.5 Update an existing org's profile (or fill it in later)
+
+To enrich an org that already exists, `PUT` it. **`name` and `plan` are required on update** — echo the current values and add the new fields:
 
 ```bash
-qovery api organization --input - <<'JSON'
-{ "name": "My Org", "plan": "USER_2025" }
-JSON
+ORG_ID="<org-uuid>"
+CUR=$(qovery api organization/$ORG_ID)
+echo "$CUR" | jq '{name, plan} + {
+  website_url: "https://example.com",
+  description: "One-line company description",
+  logo_url:   "https://logo.clearbit.com/example.com",
+  icon_url:   "https://www.google.com/s2/favicons?domain=example.com&sz=128"
+}' | qovery api organization/$ORG_ID --method PUT --input -
 ```
 
-Errors:
-- `access token is invalid or expired…` → not authenticated; go back to Phase 2.
-- `400` → check the `plan` value is one of the current plans above and `name` is present.
-
-## 3.3 Point the CLI at the new organization
+## 3.6 Point the CLI at the new organization
 
 ```bash
 qovery context set
 ```
 
-Follow the prompts to select the new organization (and later a project/environment). This sets the default context so subsequent commands target the right org.
+Select the new organization (and later a project/environment) so subsequent commands target it.
 
-## 3.4 Billing restriction on brand-new orgs (set expectations)
+## 3.7 Billing restriction on brand-new orgs (set expectations)
 
-A newly created organization has **no credit card**, so it carries `billing_deployment_restriction: NO_CREDIT_CARD`: managed (cloud) cluster creation and deployments are blocked until a card is added in the Console (**Settings → Billing**). A local **demo cluster works without a card** (see Phase 4). Tell the user this now so the restriction later isn't a surprise.
+A newly created org has **no credit card**, so it carries `billing_deployment_restriction: NO_CREDIT_CARD`: managed (cloud) cluster creation and deployments are blocked until a card is added (Console → **Settings → Billing**). A local demo cluster works without a card (Phase 4). Mention this now so it isn't a surprise.
 
-Continue to Phase 4 for next steps and the hand-off to qovery-onboard.
+Carry the **use case** from §3.1 into Phase 4.

--- a/qovery-signup/reference/phase3-create-organization.md
+++ b/qovery-signup/reference/phase3-create-organization.md
@@ -1,6 +1,6 @@
 # Phase 3 — Interview, Create, and Enrich the Organization
 
-An organization is the top-level container for everything in Qovery (projects, environments, clusters, members). Interview the user, create the org, and enrich its profile (description + logo + icon) from their website — then let Phase 4 configure Qovery for their use case.
+An organization is the top-level container for everything in Qovery (projects, environments, clusters, members). Interview the user, create the org, and enrich its profile (description + logo + icon) from their website — Phase 4 then records the sign-up, and Phase 5 configures Qovery for their use case.
 
 ## 3.1 Guided interview
 
@@ -8,7 +8,7 @@ Ask the user (one at a time, plain menus where it helps):
 
 1. **Organization name** — what to call it (case-insensitive). Usually the company or team name.
 2. **Website** — the company/product URL. Used to auto-fill the description, logo, and icon (§3.3) and stored as `website_url`. Optional but recommended; skip enrichment if they have none.
-3. **Use case** — what they want to do with Qovery: e.g. "deploy a Node.js API + Postgres to AWS", "preview environments for PRs", "run internal tools", "migrate off Heroku". This drives how Phase 4 configures Qovery and what you hand to **qovery-onboard**.
+3. **Use case** — what they want to do with Qovery: e.g. "deploy a Node.js API + Postgres to AWS", "preview environments for PRs", "run internal tools", "migrate off Heroku". It is recorded as `qovery_usage` in Phase 4 and drives how Phase 5 configures Qovery and what you hand to **qovery-onboard**.
 4. **Plan** — see §3.2. Default individuals to `USER_2025`.
 
 Confirm the name and plan before creating (org creation is a real, billable-tier resource).
@@ -86,6 +86,6 @@ Select the new organization (and later a project/environment) so subsequent comm
 
 ## 3.7 Billing restriction on brand-new orgs (set expectations)
 
-A newly created org has **no credit card**, so it carries `billing_deployment_restriction: NO_CREDIT_CARD`: managed (cloud) cluster creation and deployments are blocked until a card is added (Console → **Settings → Billing**). A local demo cluster works without a card (Phase 4). Mention this now so it isn't a surprise.
+A newly created org has **no credit card**, so it carries `billing_deployment_restriction: NO_CREDIT_CARD`: managed (cloud) cluster creation and deployments are blocked until a card is added (Console → **Settings → Billing**). A local demo cluster works without a card (Phase 5). Mention this now so it isn't a surprise.
 
-Carry the **use case** from §3.1 into Phase 4.
+Carry the **use case** from §3.1 into Phase 4 (recorded as `qovery_usage`) and Phase 5 (configuration).

--- a/qovery-signup/reference/phase4-next-steps.md
+++ b/qovery-signup/reference/phase4-next-steps.md
@@ -38,17 +38,30 @@ qovery token
 
 Save it in the user's secret manager as `QOVERY_API_TOKEN` (or `QOVERY_CLI_ACCESS_TOKEN` for the CLI). See [auth.md](auth.md) for handling rules.
 
-## 4.5 Hand off to qovery-onboard
+## 4.5 Configure for the use case (optional, no billing needed)
 
-Sign-up is done — the heavier setup lives in the **qovery-onboard** skill. Route the user there to:
-- pick a cloud provider and create a cluster (managed or BYOK),
-- structure projects and environments,
-- set security, cost, and RBAC defaults,
-- migrate from another platform if needed.
+Use the **use case** captured in Phase 3.1 to start shaping Qovery. Creating a **project** is free and needs no cluster or credit card — it's a good first structural step that matches the user's intent:
 
-If instead they just want to ship an app immediately, point them at **qovery-deploy**.
+```bash
+qovery api organization/$NEW_ORG_ID/project --field name="<use-case project, e.g. Backend API>" \
+  --field description="<from the use case>"
+```
+
+Name the project after what they're building (e.g. "Backend API", "PR Previews", "Internal Tools"). Deeper configuration — clusters, environments, deployment pipelines — is billing/cluster-gated and belongs to qovery-onboard (§4.6); don't attempt cluster or environment creation here.
+
+## 4.6 Hand off to qovery-onboard (with a brief)
+
+Sign-up is done — the heavier setup lives in the **qovery-onboard** skill. Hand it the context you gathered so it doesn't re-ask:
+
+- **Organization**: `<name>` (`<uuid>`), plan `<plan>`
+- **Use case**: `<the use case from Phase 3.1>`
+- **Website / domain**: `<website_url>`
+- **Billing**: card added? (yes → managed clusters available; no → demo cluster only)
+
+qovery-onboard will then pick a cloud provider and create a cluster (managed or BYOK), structure projects/environments, and set security/cost/RBAC defaults. If instead they just want to ship an app immediately, point them at **qovery-deploy**.
 
 Summary to give the user:
 - ✅ CLI installed and authenticated (credentials stored locally by the CLI)
-- ✅ Organization `<name>` created (id `<uuid>`)
-- ▶️ Next: add a credit card **or** `qovery demo up`, then run **qovery-onboard** to create a cluster and environments
+- ✅ Organization `<name>` created (id `<uuid>`) — profile enriched from `<website>` (description, logo, icon)
+- ✅ First project `<name>` created for the use case (if applicable)
+- ▶️ Next: add a credit card **or** `qovery demo up`, then run **qovery-onboard** (with the brief above) to create a cluster and environments

--- a/qovery-signup/reference/phase4-next-steps.md
+++ b/qovery-signup/reference/phase4-next-steps.md
@@ -1,0 +1,54 @@
+# Phase 4 — Next Steps and Hand-off
+
+The user now has an account and an organization. Close the loop: confirm it, unblock deployments, and route them to the right next skill.
+
+## 4.1 Confirm the organization exists
+
+```bash
+qovery api organization | jq -r '.results[] | "\(.name) — \(.id)"'
+```
+
+The new org should appear. If the user set the context in Phase 3, subsequent `qovery` commands target it by default.
+
+## 4.2 Unblock real deployments (add a credit card) — or use the demo cluster
+
+A brand-new org is under `NO_CREDIT_CARD` restriction: **managed clusters and cloud deployments are blocked** until a card is added.
+
+- **To deploy on real cloud infrastructure**: add a card in the Console → **Settings → Billing** (`qovery console` opens the Console in a browser). This lifts the restriction.
+- **To try Qovery with no card**: spin up a local demo cluster (k3s + Qovery on the user's machine):
+
+  ```bash
+  qovery demo up        # create the local demo cluster
+  qovery demo destroy   # tear it down when done
+  ```
+
+Recommend the demo path for someone just exploring, and the credit-card path when they're ready to deploy to their own cloud.
+
+## 4.3 Invite teammates (optional)
+
+Add members when creating the org (`--field admin_emails=…`) or later in the Console under **Settings → Members**. Enterprise plans support SSO / enterprise connections (`qovery enterprise-connection`).
+
+## 4.4 Generate an API token for automation (optional)
+
+For CI/CD or scripts, create a token and store it securely (never printed):
+
+```bash
+qovery token
+```
+
+Save it in the user's secret manager as `QOVERY_API_TOKEN` (or `QOVERY_CLI_ACCESS_TOKEN` for the CLI). See [auth.md](auth.md) for handling rules.
+
+## 4.5 Hand off to qovery-onboard
+
+Sign-up is done — the heavier setup lives in the **qovery-onboard** skill. Route the user there to:
+- pick a cloud provider and create a cluster (managed or BYOK),
+- structure projects and environments,
+- set security, cost, and RBAC defaults,
+- migrate from another platform if needed.
+
+If instead they just want to ship an app immediately, point them at **qovery-deploy**.
+
+Summary to give the user:
+- ✅ CLI installed and authenticated (credentials stored locally by the CLI)
+- ✅ Organization `<name>` created (id `<uuid>`)
+- ▶️ Next: add a credit card **or** `qovery demo up`, then run **qovery-onboard** to create a cluster and environments

--- a/qovery-signup/reference/phase4-signup-tracking.md
+++ b/qovery-signup/reference/phase4-signup-tracking.md
@@ -1,0 +1,48 @@
+# Phase 4 — Record the Sign-up (tracking & lead qualification)
+
+Mirror what `console.qovery.com` does on sign-up, so CLI/AI-agent sign-ups land in the same pipelines as web sign-ups — **clearly tagged as agent/CLI** so marketing and sales can segment them. The skill already collected the qualifying fields in Phase 3 (company/org, website, use case), so this is mostly plumbing.
+
+## 4.1 What the console fires (and what we replicate)
+
+On sign-up the console does two server-reachable things (plus browser-only GTM/HubSpot analytics we can't run in a terminal):
+
+1. **`POST /admin/userSignUp`** — Qovery's own sign-up record (name, email, `type_of_use`, `qovery_usage`, `company_name`, `user_role`, `company_size`, …).
+2. **Cargo lead ingest** → HubSpot/CRM — `{email, first_name, last_name, company, job_title, phone, website, signup_source}`. Cargo is the RevOps bridge that qualifies the lead in HubSpot.
+
+We replicate both from the CLI, setting **`signup_source: "CLI"`** (or `"AI-Agent"`) instead of `"Console"`.
+
+> **Cannot be replicated from a terminal:** GTM/HubSpot browser tracking (page analytics, the `hutk` cookie, HubSpot forms) and UTM attribution (the console reads UTMs from browser `localStorage`). That's expected — the meaningful signal here is the server-side sign-up + the `signup_source` tag.
+
+## 4.2 Run it
+
+Identity (first/last name, email) is read automatically from `qovery api account`; the qualification fields come from Phase 1/3 and are passed as env vars:
+
+```bash
+COMPANY="<org name>" \
+USE_CASE="<the use case from Phase 3.1>" \
+USER_ROLE="<their role, optional>" \
+TYPE_OF_USE=WORK \                 # PERSONAL | SCHOOL | WORK
+WEBSITE="<website_url, optional>" \
+SIGNUP_SOURCE="CLI" \              # or "AI-Agent"
+[ QOVERY_CARGO_INGEST_TOKEN="<token>" ] \
+bash templates/scripts/record-signup.sh
+```
+
+Preview exactly what would be sent, without sending, with `--dry-run`.
+
+The script:
+1. Reads identity from `qovery api account` (uses the CLI's stored auth — no token handling).
+2. `POST /admin/userSignUp` via `qovery api` — `qovery_usage` = the use case, `company_name` = the org, plus role / `type_of_use` / `company_size`. There is no `signup_source` field on this endpoint, so the source is recorded in the free-text `current_step` as `qovery-signup-skill:<SIGNUP_SOURCE>`.
+3. If `QOVERY_CARGO_INGEST_TOKEN` is set, POSTs the lead to Cargo → HubSpot with `signup_source`. If it is **not** set, this step is **skipped** (non-fatal).
+
+## 4.3 The Cargo / HubSpot token (do not commit)
+
+The Cargo ingest endpoint uses a write token. **Never hardcode it in this repo or print it.** Provide it out-of-band via the `QOVERY_CARGO_INGEST_TOKEN` environment variable, or — cleaner — have Qovery's **backend forward `/admin/userSignUp` → Cargo/HubSpot server-side**, so the skill only needs the documented `userSignUp` call and no marketing secret ever touches the CLI. Treat this token with the same rules as any credential in [auth.md](auth.md).
+
+## 4.4 Consent & tagging
+
+- Only send data the user provided during the interview; don't invent a phone number or scrape extra PII.
+- Always tag `signup_source` (`CLI` / `AI-Agent`) so these sign-ups are distinguishable from web sign-ups in HubSpot.
+- This step is best-effort and non-blocking: if tracking fails, continue to Phase 5 — never let it break the sign-up.
+
+Once recorded, continue to Phase 5 (next steps + hand-off).

--- a/qovery-signup/reference/phase5-next-steps.md
+++ b/qovery-signup/reference/phase5-next-steps.md
@@ -1,8 +1,8 @@
-# Phase 4 — Next Steps and Hand-off
+# Phase 5 — Next Steps and Hand-off
 
 The user now has an account and an organization. Close the loop: confirm it, unblock deployments, and route them to the right next skill.
 
-## 4.1 Confirm the organization exists
+## 5.1 Confirm the organization exists
 
 ```bash
 qovery api organization | jq -r '.results[] | "\(.name) — \(.id)"'
@@ -10,7 +10,7 @@ qovery api organization | jq -r '.results[] | "\(.name) — \(.id)"'
 
 The new org should appear. If the user set the context in Phase 3, subsequent `qovery` commands target it by default.
 
-## 4.2 Unblock real deployments (add a credit card) — or use the demo cluster
+## 5.2 Unblock real deployments (add a credit card) — or use the demo cluster
 
 A brand-new org is under `NO_CREDIT_CARD` restriction: **managed clusters and cloud deployments are blocked** until a card is added.
 
@@ -24,11 +24,11 @@ A brand-new org is under `NO_CREDIT_CARD` restriction: **managed clusters and cl
 
 Recommend the demo path for someone just exploring, and the credit-card path when they're ready to deploy to their own cloud.
 
-## 4.3 Invite teammates (optional)
+## 5.3 Invite teammates (optional)
 
 Add members when creating the org (`--field admin_emails=…`) or later in the Console under **Settings → Members**. Enterprise plans support SSO / enterprise connections (`qovery enterprise-connection`).
 
-## 4.4 Generate an API token for automation (optional)
+## 5.4 Generate an API token for automation (optional)
 
 For CI/CD or scripts, create a token and store it securely (never printed):
 
@@ -38,7 +38,7 @@ qovery token
 
 Save it in the user's secret manager as `QOVERY_API_TOKEN` (or `QOVERY_CLI_ACCESS_TOKEN` for the CLI). See [auth.md](auth.md) for handling rules.
 
-## 4.5 Configure for the use case (optional, no billing needed)
+## 5.5 Configure for the use case (optional, no billing needed)
 
 Use the **use case** captured in Phase 3.1 to start shaping Qovery. Creating a **project** is free and needs no cluster or credit card — it's a good first structural step that matches the user's intent:
 
@@ -47,9 +47,9 @@ qovery api organization/$NEW_ORG_ID/project --field name="<use-case project, e.g
   --field description="<from the use case>"
 ```
 
-Name the project after what they're building (e.g. "Backend API", "PR Previews", "Internal Tools"). Deeper configuration — clusters, environments, deployment pipelines — is billing/cluster-gated and belongs to qovery-onboard (§4.6); don't attempt cluster or environment creation here.
+Name the project after what they're building (e.g. "Backend API", "PR Previews", "Internal Tools"). Deeper configuration — clusters, environments, deployment pipelines — is billing/cluster-gated and belongs to qovery-onboard (§5.6); don't attempt cluster or environment creation here.
 
-## 4.6 Hand off to qovery-onboard (with a brief)
+## 5.6 Hand off to qovery-onboard (with a brief)
 
 Sign-up is done — the heavier setup lives in the **qovery-onboard** skill. Hand it the context you gathered so it doesn't re-ask:
 

--- a/qovery-signup/templates/scripts/check-and-install-cli.sh
+++ b/qovery-signup/templates/scripts/check-and-install-cli.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# check-and-install-cli.sh — check whether the Qovery CLI is installed and, if not,
+# print the right install command for this OS. Does NOT run privileged installs on its own.
+#
+# Usage:
+#   bash check-and-install-cli.sh            # detect + advise
+#   bash check-and-install-cli.sh --install  # additionally attempt `brew install` on macOS if brew exists
+#
+# Exit codes: 0 = CLI present, 1 = CLI missing (advice printed), 2 = missing + auto-install attempted.
+set -euo pipefail
+
+TRY_INSTALL="no"
+[ "${1:-}" = "--install" ] && TRY_INSTALL="yes"
+
+if command -v qovery >/dev/null 2>&1; then
+  echo "Qovery CLI is installed: $(qovery version 2>/dev/null | head -1)"
+  echo "Update anytime with: qovery upgrade"
+  exit 0
+fi
+
+echo "Qovery CLI is NOT installed."
+OS="$(uname -s 2>/dev/null || echo unknown)"
+case "$OS" in
+  Darwin)
+    echo "Recommended (macOS): brew install qovery-cli"
+    if [ "$TRY_INSTALL" = "yes" ] && command -v brew >/dev/null 2>&1; then
+      echo "Attempting: brew install qovery-cli"
+      brew install qovery-cli
+      command -v qovery >/dev/null 2>&1 && { echo "Installed: $(qovery version | head -1)"; exit 0; }
+      exit 2
+    fi
+    command -v brew >/dev/null 2>&1 || echo "Homebrew not found — install it from https://brew.sh or use a release binary (below)."
+    ;;
+  Linux)
+    echo "Arch Linux:      yay qovery-cli"
+    echo "Any Linux:       download the latest release binary and put it on your PATH:"
+    echo "                 https://github.com/Qovery/qovery-cli/releases"
+    echo "                 (unpack, then: sudo mv qovery /usr/local/bin/qovery && sudo chmod +x /usr/local/bin/qovery)"
+    ;;
+  *)
+    echo "Windows (Scoop): scoop install qovery-cli"
+    echo "Or download a release binary: https://github.com/Qovery/qovery-cli/releases"
+    ;;
+esac
+
+echo
+echo "After installing, verify with: qovery version"
+exit 1

--- a/qovery-signup/templates/scripts/enrich-from-website.sh
+++ b/qovery-signup/templates/scripts/enrich-from-website.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# enrich-from-website.sh — derive candidate org profile fields (description, logo, icon)
+# from a company's website, for populating a Qovery organization.
+#
+# Usage: bash enrich-from-website.sh <website-url-or-domain>
+# Output: JSON on stdout: { website_url, domain, description, logo_url, icon_url }
+#
+# These are CANDIDATES — show them to the user and confirm before writing them to the org.
+# Extraction is best-effort (og:image / og:description / meta description / icon links from
+# the raw HTML) with deterministic fallbacks (Clearbit logo, Google favicon) so there is
+# always a usable logo_url and icon_url.
+set -euo pipefail
+
+RAW="${1:?usage: enrich-from-website.sh <website-url-or-domain>}"
+
+# Normalize to a URL + bare domain
+case "$RAW" in
+  http://*|https://*) URL="$RAW" ;;
+  *) URL="https://$RAW" ;;
+esac
+DOMAIN="$(printf '%s' "$URL" | sed -E 's~^https?://~~; s~/.*$~~; s~^www\.~~')"
+
+HTML="$(curl -sL --max-time 20 -A "Mozilla/5.0 (QoverySkill qovery-signup)" "$URL" 2>/dev/null || true)"
+
+# Pull the content="..." value from the first matching meta tag (handles attr order both ways)
+meta_content() { # $1 = attr (e.g. property="og:image")
+  printf '%s' "$HTML" \
+    | tr '\n' ' ' \
+    | grep -oiE "<meta[^>]*$1[^>]*>" \
+    | head -1 \
+    | grep -oiE 'content="[^"]*"' \
+    | head -1 \
+    | sed -E 's/^content="//I; s/"$//'
+}
+link_href() { # $1 = rel value (e.g. icon, apple-touch-icon)
+  printf '%s' "$HTML" \
+    | tr '\n' ' ' \
+    | grep -oiE "<link[^>]*rel=\"[^\"]*$1[^\"]*\"[^>]*>" \
+    | head -1 \
+    | grep -oiE 'href="[^"]*"' \
+    | head -1 \
+    | sed -E 's/^href="//I; s/"$//'
+}
+decode() { # decode the few HTML entities that commonly appear in URLs/descriptions
+  printf '%s' "${1:-}" | sed -E 's/&amp;/\&/g; s/&#38;/\&/g; s/&quot;/"/g; s/&#39;/'"'"'/g; s/&apos;/'"'"'/g'
+}
+absolutize() { # $1 = maybe-relative URL
+  case "${1:-}" in
+    "" ) echo "" ;;
+    http://*|https://*) echo "$1" ;;
+    //*) echo "https:$1" ;;
+    /*) echo "https://$DOMAIN$1" ;;
+    *) echo "https://$DOMAIN/$1" ;;
+  esac
+}
+
+DESC="$(decode "$(meta_content 'property="og:description"')")"
+[ -n "$DESC" ] || DESC="$(decode "$(meta_content 'name="description"')")"
+
+OG_IMAGE="$(decode "$(absolutize "$(meta_content 'property="og:image"')")")"
+SITE_ICON="$(decode "$(absolutize "$(link_href 'apple-touch-icon')")")"
+[ -n "$SITE_ICON" ] || SITE_ICON="$(decode "$(absolutize "$(link_href 'icon')")")"
+
+CLEARBIT="https://logo.clearbit.com/$DOMAIN"
+GFAVICON="https://www.google.com/s2/favicons?domain=$DOMAIN&sz=128"
+
+# Best guesses + all discovered candidates so the agent can offer choices.
+# Note: og:image is usually a social share card (wide); Clearbit is usually a square logo.
+LOGO="${OG_IMAGE:-$CLEARBIT}"
+ICON="${SITE_ICON:-$GFAVICON}"
+
+jq -n \
+  --arg website_url "$URL" --arg domain "$DOMAIN" --arg description "$DESC" \
+  --arg logo_url "$LOGO" --arg icon_url "$ICON" \
+  --arg og_image "$OG_IMAGE" --arg site_icon "$SITE_ICON" \
+  --arg clearbit "$CLEARBIT" --arg gfavicon "$GFAVICON" \
+  '{
+     website_url:$website_url, domain:$domain, description:$description,
+     logo_url:$logo_url, icon_url:$icon_url,
+     candidates: {
+       logos:  ([$og_image, $clearbit]  | map(select(. != "")) | unique),
+       icons:  ([$site_icon, $gfavicon] | map(select(. != "")) | unique)
+     }
+   }'

--- a/qovery-signup/templates/scripts/record-signup.sh
+++ b/qovery-signup/templates/scripts/record-signup.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# record-signup.sh — record a sign-up for tracking + lead qualification, mirroring what
+# console.qovery.com does, but tagged as a CLI/agent sign-up.
+#
+# It fires TWO things:
+#   1. POST /admin/userSignUp  (Qovery's own signup record) via `qovery api` (CLI auth)
+#   2. Cargo lead ingest -> HubSpot/CRM, with signup_source (only if a token is provided)
+#
+# Identity (first/last name, email) is read automatically from `qovery api account`.
+# Qualification fields come from the Phase 1/3 interview and are passed as env vars.
+#
+# Usage:
+#   COMPANY="Acme" USE_CASE="PR preview environments" USER_ROLE="CTO" \
+#   TYPE_OF_USE=WORK WEBSITE="https://acme.com" SIGNUP_SOURCE="CLI" \
+#   [QOVERY_CARGO_INGEST_TOKEN=...] \
+#   bash record-signup.sh [--dry-run]
+#
+# --dry-run prints the exact payloads and does not send anything.
+# SECURITY: never prints the Cargo token; skips the Cargo step if the token is unset.
+set -euo pipefail
+
+DRY="no"; [ "${1:-}" = "--dry-run" ] && DRY="yes"
+
+command -v qovery >/dev/null 2>&1 || { echo "ERROR: qovery CLI not found."; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq not found."; exit 2; }
+
+# Qualification inputs (from the interview) — with sensible defaults
+COMPANY="${COMPANY:-}"
+USE_CASE="${USE_CASE:-}"
+USER_ROLE="${USER_ROLE:-}"
+TYPE_OF_USE="${TYPE_OF_USE:-WORK}"          # PERSONAL | SCHOOL | WORK
+COMPANY_SIZE="${COMPANY_SIZE:-}"            # 1-10 | 11-50 | 51-200 | 201-500 | 500+
+WEBSITE="${WEBSITE:-}"
+PHONE="${PHONE:-}"
+SIGNUP_SOURCE="${SIGNUP_SOURCE:-CLI}"       # tags agent/CLI signups distinctly from "Console"
+[ -n "$USE_CASE" ] || { echo "ERROR: set USE_CASE (maps to qovery_usage)."; exit 2; }
+
+# Identity from the authenticated account
+ACC="$(qovery api account 2>/dev/null || true)"
+if printf '%s' "$ACC" | jq -e . >/dev/null 2>&1; then
+  FIRST="$(printf '%s' "$ACC" | jq -r '.first_name // ""')"
+  LAST="$(printf '%s' "$ACC" | jq -r '.last_name // ""')"
+  EMAIL="$(printf '%s' "$ACC" | jq -r '.communication_email // ""')"
+elif [ "$DRY" = "yes" ]; then
+  FIRST="Jane"; LAST="Doe"; EMAIL="jane@example.com"   # placeholders so --dry-run works unauthenticated
+else
+  echo "ERROR: could not read account (are you authenticated? run 'qovery auth --headless')."; exit 2
+fi
+
+# 1) Qovery signup record: POST /admin/userSignUp (no signup_source field, so the source
+#    goes in current_step as a free-text marker)
+SIGNUP_BODY="$(jq -n \
+  --arg first_name "$FIRST" --arg last_name "$LAST" --arg user_email "$EMAIL" \
+  --arg type_of_use "$TYPE_OF_USE" --arg qovery_usage "$USE_CASE" \
+  --arg company_name "$COMPANY" --arg user_role "$USER_ROLE" \
+  --arg company_size "$COMPANY_SIZE" --arg current_step "qovery-signup-skill:${SIGNUP_SOURCE}" \
+  '{first_name:$first_name, last_name:$last_name, user_email:$user_email,
+    type_of_use:$type_of_use, qovery_usage:$qovery_usage, current_step:$current_step}
+   + (if $company_name != "" then {company_name:$company_name} else {} end)
+   + (if $user_role   != "" then {user_role:$user_role}     else {} end)
+   + (if $company_size != "" then {company_size:$company_size} else {} end)')"
+
+# 2) Cargo -> HubSpot lead ingest (public model id from the console; token via env, never committed)
+CARGO_MODEL="7e42e545-bdee-438b-b2dc-3799e95bf046"
+CARGO_URL="https://api.getcargo.io/v1/models/${CARGO_MODEL}/records/ingest"
+CARGO_BODY="$(jq -n \
+  --arg email "$EMAIL" --arg first_name "$FIRST" --arg last_name "$LAST" \
+  --arg company "$COMPANY" --arg job_title "$USER_ROLE" --arg phone "$PHONE" \
+  --arg website "$WEBSITE" --arg signup_source "$SIGNUP_SOURCE" \
+  '{email:$email, first_name:$first_name, last_name:$last_name, company:$company,
+    job_title:$job_title, phone:$phone, website:$website, signup_source:$signup_source}')"
+
+if [ "$DRY" = "yes" ]; then
+  echo "# DRY RUN — nothing sent"
+  echo "## POST /admin/userSignUp"; echo "$SIGNUP_BODY" | jq .
+  echo "## Cargo ingest ($CARGO_URL?token=***)"; echo "$CARGO_BODY" | jq .
+  [ -n "${QOVERY_CARGO_INGEST_TOKEN:-}" ] && echo "(Cargo token present — would send)" || echo "(no QOVERY_CARGO_INGEST_TOKEN — Cargo step would be SKIPPED)"
+  exit 0
+fi
+
+# Send 1) via the CLI (uses stored auth, no token handling)
+if printf '%s' "$SIGNUP_BODY" | qovery api admin/userSignUp --method POST --input - >/dev/null 2>&1; then
+  echo "Recorded Qovery sign-up (POST /admin/userSignUp), source=${SIGNUP_SOURCE}."
+else
+  echo "WARN: POST /admin/userSignUp did not succeed (non-fatal)."
+fi
+
+# Send 2) only if the ingest token is provided
+if [ -n "${QOVERY_CARGO_INGEST_TOKEN:-}" ]; then
+  code="$(curl -s -o /dev/null -w '%{http_code}' -X POST "${CARGO_URL}?token=${QOVERY_CARGO_INGEST_TOKEN}" \
+    -H "Content-Type: application/json" -d "$CARGO_BODY")"
+  case "$code" in
+    2*) echo "Sent lead to HubSpot funnel via Cargo (signup_source=${SIGNUP_SOURCE}).";;
+    *)  echo "WARN: Cargo ingest returned HTTP ${code} (non-fatal).";;
+  esac
+else
+  echo "Cargo/HubSpot step skipped: set QOVERY_CARGO_INGEST_TOKEN to enable lead-funnel sync (never commit it)."
+fi

--- a/qovery/SKILL.md
+++ b/qovery/SKILL.md
@@ -70,6 +70,7 @@ Analyze the user's message and route to the appropriate specialized skill. **Aut
 | Preview environment, PR environment, test branch | `qovery-preview` | "preview for PR-123", "test this branch", "preview environment", "clone for PR" |
 | Terraformize existing setup, convert to IaC | `qovery-terraform` | "terraformize", "convert to terraform", "export as IaC", "terraform manifests", "infrastructure as code" |
 | Scoped/least-privilege API token, OPA/Rego policy token | `qovery-policy-token` | "restricted token", "scoped token", "least-privilege token", "policy token", "OPA/Rego token", "token that can only deploy / never delete", "token for an AI agent" |
+| New to Qovery, no account yet, sign up, create organization | `qovery-signup` | "sign up", "create an account", "install the CLI and log in", "create a new organization", "get started from scratch" |
 
 ### Remote Development Environments (RDEs)
 
@@ -327,6 +328,7 @@ Quick reference for all specialized skills. When routing, tell the user which sk
 | `qovery-preview` | Preview environments for PRs with auto-shutdown | "Preview PR-123" |
 | `qovery-terraform` | Generate Terraform manifests from existing Qovery setup | "Terraformize my setup" |
 | `qovery-policy-token` | Create and verify a scoped, least-privilege API Policy Token (OPA/Rego) | "Restricted token that can only deploy" |
+| `qovery-signup` | Sign up, install/auth the CLI, and create your first organization | "I'm new to Qovery, help me sign up" |
 
 ---
 

--- a/scripts/sync-shared.sh
+++ b/scripts/sync-shared.sh
@@ -12,7 +12,7 @@ cd "$REPO_ROOT"
 # Each line: SRC | SKILL_LIST (space-separated)
 SYNC_MAP=$(cat <<'EOF'
 console-url-detection.md | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-policy-token
-auth.md                  | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-policy-token
+auth.md                  | qovery qovery-deploy qovery-troubleshoot qovery-onboard qovery-optimize qovery-speedup qovery-preview qovery-terraform qovery-policy-token qovery-signup
 pricing/aws.md           | qovery-optimize
 pricing/gcp.md           | qovery-optimize
 pricing/azure.md         | qovery-optimize


### PR DESCRIPTION
## Summary

New skill **`qovery-signup`** that takes a brand-new user from nothing to a working Qovery account and first organization, then hands off to `qovery-onboard`.

**How authentication is handled** (the core question): it's delegated entirely to the **Qovery CLI's own credential store**. The user signs in once with `qovery auth --headless` (the first OAuth login *is* the sign-up — there's no separate registration and no API to create an account). After that, every `qovery` / `qovery api` call authenticates internally, so **no raw token is ever requested, printed, or stored** — consistent with `_shared/auth.md`.

## Workflow

1. **CLI setup** — detect OS, check `qovery` is installed (install per platform if missing: brew / scoop / release binary), verify version
2. **Authenticate** — `qovery auth --headless` (interactive; prints a URL the user opens in a browser). Verify with `qovery api organization`
3. **Create organization** — confirm name + plan, then `qovery api organization --field name=... --field plan=USER_2025`; set context with `qovery context set`; flag the `NO_CREDIT_CARD` restriction
4. **Next steps** — add a credit card *or* `qovery demo up` (no card), invite teammates, hand off to `qovery-onboard`

## What's included

- `qovery-signup/SKILL.md` (133 lines), slash command, 4 reference phase files, `check-and-install-cli.sh`
- Wired into `install.sh`, `local-install.sh`, `scripts/sync-shared.sh` (auth.md), `README.md`, the `qovery` router, and `evals/qovery-signup.json` (3 scenarios)

## Verified against the live CLI/API

- `qovery auth --headless` flag exists; the not-authed error text is `"access token is invalid or expired. Sign in using 'qovery auth' or 'qovery auth --headless' command."`
- There is **no `qovery organization` command** — the CLI's own `qovery api` help documents `qovery api organization --field name=my-org --field plan=FREE`, so org management goes through `qovery api`
- Create-org API: `POST /organization`, required `name` + `plan`; current plans are the **2025** tiers (`USER_2025` … `ENTERPRISE_2025`); `FREE`/`PROFESSIONAL`/`BUSINESS` are deprecated; new orgs carry `billing_deployment_restriction: NO_CREDIT_CARD`
- `qovery context set`, `qovery demo up/destroy`, and install methods (brew/scoop/release binary) confirmed
- SKILL.md ≤ 500 lines, links resolve, no anti-patterns, eval JSON valid, installer links the skill (10 skills / 30 locations), `check-and-install-cli.sh` passes `bash -n` and runs correctly

## Reviewer notes

- Overlaps intentionally with `qovery-onboard` but sits *before* it: signup = account + org; onboard = clusters/projects/RBAC. The skill hands off explicitly.
- The auth step is interactive (browser) — the skill instructs the agent to have the user run `! qovery auth --headless` and cannot complete the OAuth step on their behalf.