### PR TITLE
Feat/qovery signup skill

### DIFF
--- a/evals/qovery-signup.json
+++ b/evals/qovery-signup.json
@@ -7,18 +7,18 @@
       "Checks whether the Qovery CLI is installed (command -v qovery / qovery version) and installs it per the user's OS if missing (brew on macOS, scoop on Windows, release binary on Linux)",
       "Explains that the first login creates the account, and has the user run `qovery auth --headless` (interactive, in Claude Code via `! qovery auth --headless`) to complete OAuth in a browser — never asking for or printing a raw token",
       "Verifies authentication with `qovery api organization` (JSON = signed in; the 'access token is invalid or expired' message = re-run auth)",
-      "Confirms an organization name and plan (defaulting to USER_2025, noting FREE/PROFESSIONAL are deprecated) before creating it via `qovery api organization --field name=... --field plan=...`",
+      "Confirms only the organization name (never asks the user to choose a plan or exposes internal plan names) and creates the org on BUSINESS_2025 by default via `qovery api organization --field name=... --field plan=BUSINESS_2025`",
       "Sets the CLI context, warns about the NO_CREDIT_CARD deployment restriction (offers `qovery demo up` as a no-card option), and hands off to qovery-onboard"
     ]
   },
   {
     "skills": ["qovery-signup"],
-    "query": "Create a new Qovery organization called Acme on the team plan.",
+    "query": "Create a new Qovery organization called Acme.",
     "files": [],
     "expected_behavior": [
       "Ensures the CLI is installed and the user is authenticated first (runs qovery auth --headless if `qovery api organization` returns the invalid/expired-token error)",
-      "Maps 'team plan' to the current plan value TEAM_2025 and confirms name + plan with the user before creating",
-      "Creates the org with `qovery api organization --field name=Acme --field plan=TEAM_2025` (using the CLI's stored credentials, not a manually supplied token) and captures the returned id",
+      "Does NOT ask the user to choose a plan and does not surface internal plan names; defaults to BUSINESS_2025",
+      "Creates the org with `qovery api organization --field name=Acme --field plan=BUSINESS_2025` (using the CLI's stored credentials, not a manually supplied token) and captures the returned id",
       "Runs `qovery context set` so the CLI targets the new organization",
       "Surfaces the credit-card requirement for managed clusters/deployments and points to qovery-onboard for cluster + environment setup"
     ]
@@ -28,9 +28,9 @@
     "query": "Sign me up and set up an org for my company at https://acme.com — we want to run preview environments for our PRs.",
     "files": [],
     "expected_behavior": [
-      "Ensures CLI + auth first, then interviews: confirms the organization name, records the website (https://acme.com) and the use case (PR preview environments), and the plan",
+      "Ensures CLI + auth first, then interviews: confirms the organization name, records the website (https://acme.com) and the use case (PR preview environments) — without asking for a plan (defaults to BUSINESS_2025)",
       "Runs enrich-from-website.sh on acme.com to derive a candidate description, logo_url, and icon_url (with Clearbit/Google-favicon fallbacks), and shows them to the user to confirm before setting anything",
-      "Creates the organization via `qovery api organization --input -` including name, plan, website_url, description, logo_url, and icon_url",
+      "Creates the organization via `qovery api organization --input -` including name, plan (BUSINESS_2025, not asked), website_url, description, logo_url, and icon_url",
       "Configures for the use case without needing billing — e.g. creates a first project (POST organization/{id}/project) named for PR previews — and notes clusters/environments are handled by qovery-onboard",
       "Hands off to qovery-onboard with a brief (org id, use case = PR previews, website, billing status), and mentions qovery-preview as the eventual skill for per-PR environments"
     ]

--- a/qovery-signup/SKILL.md
+++ b/qovery-signup/SKILL.md
@@ -38,7 +38,7 @@ SKILL_NAME="qovery-signup"
 >
 > **First login = sign-up.** A brand-new user does not "register" separately — the account is created automatically on the first successful OAuth login. There is no API to create an account.
 >
-> **Confirm the org name and plan before creating.** Organization creation is a real, billable-tier resource. Get explicit confirmation of both. Default individuals to `USER_2025`.
+> **Do NOT ask the user to choose a plan, and never expose internal plan names.** Always create the organization on **`BUSINESS_2025`** by default (the individual tier isn't customer-selectable and Enterprise pricing is custom). Confirm only the org **name** before creating (org creation is a real, billable-tier resource). Deviate from `BUSINESS_2025` only if the user explicitly names a plan themselves.
 >
 > **There is no `qovery organization` CLI command.** Manage organizations through `qovery api organization …` (which uses the CLI's auth) or the REST API — not a CLI noun.
 >
@@ -64,7 +64,7 @@ For setting up clusters, projects, environments, RBAC, and cloud providers **aft
 Sign up + create an organization:
 - [ ] Phase 1 — CLI setup: detect OS, check `qovery` is installed (install if missing), verify version
 - [ ] Phase 2 — Authenticate: run `qovery auth --headless` (first login creates the account); verify auth
-- [ ] Phase 3 — Interview + create + enrich: ask name, website, use case, plan; create the org; enrich its profile (description, logo, icon) from the website; set context
+- [ ] Phase 3 — Interview + create + enrich: ask name, website, use case (NOT plan — default `BUSINESS_2025`); create the org; enrich its profile (description, logo, icon) from the website; set context
 - [ ] Phase 4 — Record sign-up: fire `POST /admin/userSignUp` + the Cargo/HubSpot lead ingest, tagged `signup_source=CLI` (best-effort, non-blocking)
 - [ ] Phase 5 — Configure + hand off: optional first project for the use case, billing/demo-cluster note, invite team, hand a brief to qovery-onboard
 ```
@@ -83,7 +83,7 @@ Sign up + create an organization:
 | Auth | [reference/auth.md](reference/auth.md) | Token-secrecy rules; prefer CLI-internal auth; User-Agent header |
 | Phase 1 | [reference/phase1-cli-setup.md](reference/phase1-cli-setup.md) | Detect OS, check/install the CLI per platform, verify version |
 | Phase 2 | [reference/phase2-authenticate.md](reference/phase2-authenticate.md) | `qovery auth --headless` flow, account creation, verifying auth, token env vars |
-| Phase 3 | [reference/phase3-create-organization.md](reference/phase3-create-organization.md) | Interview (name, website, use case, plan); create via `qovery api`; enrich profile (description/logo/icon) from the website; update via PUT; set context; billing restriction |
+| Phase 3 | [reference/phase3-create-organization.md](reference/phase3-create-organization.md) | Interview (name, website, use case — plan is auto `BUSINESS_2025`, never asked); create via `qovery api`; enrich profile (description/logo/icon) from the website; update via PUT; set context; billing restriction |
 | Phase 4 | [reference/phase4-signup-tracking.md](reference/phase4-signup-tracking.md) | Record the sign-up for tracking + lead qualification (mirrors the console): `POST /admin/userSignUp` + Cargo→HubSpot ingest, tagged `signup_source=CLI`; token via env, never committed |
 | Phase 5 | [reference/phase5-next-steps.md](reference/phase5-next-steps.md) | Configure for the use case (optional first project), add credit card / `qovery demo up`, invite teammates, hand a brief to qovery-onboard |
 
@@ -111,7 +111,7 @@ qovery api organization
 bash templates/scripts/enrich-from-website.sh example.com
 
 # 3b. Create an organization (uses the CLI's stored auth; no token handling)
-qovery api organization --field name="My Org" --field plan=USER_2025
+qovery api organization --field name="My Org" --field plan=BUSINESS_2025   # plan is always BUSINESS_2025; never ask the user
 #    …or with the enriched profile via --input (see Phase 3.4)
 
 # 4. Record the sign-up for tracking + lead qualification (tagged CLI; --dry-run to preview)
@@ -124,18 +124,11 @@ qovery context set
 qovery demo up
 ```
 
-## Organization plans
+## Organization plan (automatic)
 
-Pass one of these as `plan` when creating (2025 plans are current; `FREE` / `PROFESSIONAL` / `BUSINESS` are deprecated):
+The skill **always creates the organization on `BUSINESS_2025`** and **never asks the user to choose a plan**. Internal plan names (individual/team/enterprise tiers) are not surfaced in the sign-up flow — the individual tier isn't customer-selectable and Enterprise pricing is custom, so exposing a picker is confusing and off-brand. Users change plan later in the Console (**Settings → Billing**); pricing is at <https://www.qovery.com/pricing>.
 
-| Plan | For |
-|---|---|
-| `USER_2025` | Individuals / getting started (default) |
-| `TEAM_2025` | Small teams |
-| `BUSINESS_2025` | Growing companies |
-| `ENTERPRISE_2025` | Large orgs (SSO, advanced controls) |
-
-> Always verify current plan names and pricing at <https://www.qovery.com/pricing> — plans change over time.
+Only deviate from `BUSINESS_2025` if the user *explicitly* names a specific plan themselves — never prompt for it.
 
 ## Reference links
 

--- a/qovery-signup/commands/qovery-signup.md
+++ b/qovery-signup/commands/qovery-signup.md
@@ -5,13 +5,13 @@ description: Sign up for Qovery and create your first organization
 Get started with Qovery from scratch: install the CLI if needed, authenticate, and create your first organization.
 
 If arguments are provided, use them as context:
-- `$ARGUMENTS` — a desired organization name and/or plan (e.g. "org=Acme plan=USER_2025")
+- `$ARGUMENTS` — a desired organization name and/or company website (e.g. "org=Acme website=https://acme.com")
 
 Follow the qovery-signup skill to:
 1. Check the Qovery CLI is installed (install it if missing) and verify the version
 2. Sign in with `qovery auth --headless` — the first login creates the account (no separate registration)
-3. Confirm an organization name + plan, then create it via `qovery api organization`
+3. Confirm an organization name, then create it via `qovery api organization` (plan defaults to `BUSINESS_2025` — do not ask the user to pick a plan)
 4. Set the CLI context and cover next steps (billing, demo cluster, inviting the team)
 5. Hand off to the qovery-onboard skill for cluster and environment setup
 
-CRITICAL: Never ask for, print, or store raw tokens — authentication is handled by the CLI's own credential store after `qovery auth`. Confirm the org name and plan before creating.
+CRITICAL: Never ask for, print, or store raw tokens — authentication is handled by the CLI's own credential store after `qovery auth`. Confirm only the org name before creating; the plan is always `BUSINESS_2025` and is never surfaced to the user.

--- a/qovery-signup/reference/phase3-create-organization.md
+++ b/qovery-signup/reference/phase3-create-organization.md
@@ -9,22 +9,14 @@ Ask the user (one at a time, plain menus where it helps):
 1. **Organization name** — what to call it (case-insensitive). Usually the company or team name.
 2. **Website** — the company/product URL. Used to auto-fill the description, logo, and icon (§3.3) and stored as `website_url`. Optional but recommended; skip enrichment if they have none.
 3. **Use case** — what they want to do with Qovery: e.g. "deploy a Node.js API + Postgres to AWS", "preview environments for PRs", "run internal tools", "migrate off Heroku". It is recorded as `qovery_usage` in Phase 4 and drives how Phase 5 configures Qovery and what you hand to **qovery-onboard**.
-4. **Plan** — see §3.2. Default individuals to `USER_2025`.
 
-Confirm the name and plan before creating (org creation is a real, billable-tier resource).
+The plan is chosen automatically (§3.2) — **do not ask the user to pick one**. Confirm the organization **name** before creating (org creation is a real, billable-tier resource).
 
-## 3.2 Plans
+## 3.2 Plan — chosen automatically, do not ask
 
-Current plans are the **2025** tiers — `FREE`, `PROFESSIONAL`, and `BUSINESS` are deprecated:
+Always create the organization on **`BUSINESS_2025`**. **Do not ask the user which plan to use, and do not surface plan names** — the tiers are internal (the individual tier isn't customer-selectable and Enterprise pricing is custom), so exposing them in a sign-up flow is confusing and off-brand. Users can change plan later in the Console (**Settings → Billing**); pricing lives at <https://www.qovery.com/pricing>.
 
-| Plan value | For |
-|---|---|
-| `USER_2025` | Individuals / getting started (default) |
-| `TEAM_2025` | Small teams |
-| `BUSINESS_2025` | Growing companies |
-| `ENTERPRISE_2025` | Large orgs (SSO, advanced controls) |
-
-Verify current names/pricing at <https://www.qovery.com/pricing> if unsure.
+(Only deviate from the `BUSINESS_2025` default if the user *explicitly* names a specific plan themselves — never prompt for it.)
 
 ## 3.3 Enrich from the website (description, logo, icon)
 
@@ -46,7 +38,7 @@ There is no `qovery organization` command; use `qovery api`, which reuses the st
 NEW_ORG_ID=$(qovery api organization --input - <<JSON | jq -r '.id'
 {
   "name": "My Org",
-  "plan": "USER_2025",
+  "plan": "BUSINESS_2025",
   "website_url": "https://example.com",
   "description": "One-line company description",
   "logo_url": "https://logo.clearbit.com/example.com",
@@ -57,7 +49,7 @@ JSON
 echo "Created organization: $NEW_ORG_ID"
 ```
 
-For a bare org (no website), the short form is enough: `qovery api organization --field name="My Org" --field plan=USER_2025`.
+For a bare org (no website), the short form is enough: `qovery api organization --field name="My Org" --field plan=BUSINESS_2025`.
 
 Errors: `access token is invalid or expired…` → re-do Phase 2; `400` → check `plan` is a current value and `name` is present; `409` → the name is taken.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the `qovery-signup` skill that takes a brand-new user from no account to a working Qovery organization, then hands off to `qovery-onboard`. Previously there was no sign-up path; now the skill checks or installs the CLI, authenticates via `qovery auth --headless` (first login creates the account), and creates the org through `qovery api`.

**New Features**
- Creates organizations on `BUSINESS_2025` by default and never asks the user to pick a plan or surfaces plan names.
- Enriches the org profile (description, logo, icon) from the company website via `enrich-from-website.sh`, confirming candidates with the user before writing.
- Records sign-ups for tracking and HubSpot lead qualification, tagged `signup_source=CLI`/`AI-Agent`, best-effort and non-blocking; the Cargo token comes only from `QOVERY_CARGO_INGEST_TOKEN`.
- Authentication is delegated entirely to the CLI's credential store — no raw tokens are ever requested, printed, or stored.
- Wires the skill into both install scripts, the shared auth sync, the `qovery` router, the README, and evals.

<sup>Written for commit d56d8771d2c5e2f216c86edf184d4a4feae70071. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Qovery/qovery-skills/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

