### PR TITLE
fix(tracking): fix skill tracking when auth with the cli

### DIFF
--- a/qovery-deploy/SKILL.md
+++ b/qovery-deploy/SKILL.md
@@ -17,14 +17,23 @@ This skill deploys applications to Kubernetes via Qovery. It analyzes the projec
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
-QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
-  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery-deploy"
-curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Token $QOVERY_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery-deploy (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery-deploy"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery-deploy (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 > **API rule:** The `User-Agent` header above is required on **every** `curl` call to `api.qovery.com` — not just this tracking call. Never omit it.

--- a/qovery-deploy/SKILL.md
+++ b/qovery-deploy/SKILL.md
@@ -17,22 +17,19 @@ This skill deploys applications to Kubernetes via Qovery. It analyzes the projec
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery-deploy (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery-deploy"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery-deploy (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-deploy"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-deploy"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery-onboard/SKILL.md
+++ b/qovery-onboard/SKILL.md
@@ -19,14 +19,23 @@ The skill is opinionated: it does NOT dump configuration options on the user. It
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
-QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
-  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery-onboard"
-curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Token $QOVERY_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery-onboard (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery-onboard"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery-onboard (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 > **API rule:** The `User-Agent` header above is required on **every** `curl` call to `api.qovery.com` — not just this tracking call. Never omit it.

--- a/qovery-onboard/SKILL.md
+++ b/qovery-onboard/SKILL.md
@@ -19,22 +19,19 @@ The skill is opinionated: it does NOT dump configuration options on the user. It
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery-onboard (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery-onboard"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery-onboard (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-onboard"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-onboard"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery-optimize/SKILL.md
+++ b/qovery-optimize/SKILL.md
@@ -24,14 +24,23 @@ It is NOT about blindly reducing everything to minimum. It is **intelligent opti
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
-QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
-  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery-optimize"
-curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Token $QOVERY_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery-optimize (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery-optimize"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery-optimize (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 > **API rule:** The `User-Agent` header above is required on **every** `curl` call to `api.qovery.com` — not just this tracking call. Never omit it.

--- a/qovery-optimize/SKILL.md
+++ b/qovery-optimize/SKILL.md
@@ -24,22 +24,19 @@ It is NOT about blindly reducing everything to minimum. It is **intelligent opti
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery-optimize (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery-optimize"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery-optimize (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-optimize"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-optimize"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery-policy-token/SKILL.md
+++ b/qovery-policy-token/SKILL.md
@@ -19,22 +19,19 @@ An **API Policy Token** is a second kind of Qovery organization token whose auth
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery-policy-token"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-policy-token"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-policy-token"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery-policy-token/SKILL.md
+++ b/qovery-policy-token/SKILL.md
@@ -19,14 +19,23 @@ An **API Policy Token** is a second kind of Qovery organization token whose auth
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
-QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
-  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery-policy-token"
-curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Token $QOVERY_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery-policy-token"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery-policy-token (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 > **API rule:** The `User-Agent` header above is required on **every** `curl` call to `api.qovery.com` — not just this tracking call. Never omit it.

--- a/qovery-preview/SKILL.md
+++ b/qovery-preview/SKILL.md
@@ -17,22 +17,19 @@ This skill creates preview environments on Kubernetes via Qovery. It detects PR/
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery-preview (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery-preview"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery-preview (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-preview"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-preview"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery-preview/SKILL.md
+++ b/qovery-preview/SKILL.md
@@ -17,14 +17,23 @@ This skill creates preview environments on Kubernetes via Qovery. It detects PR/
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
-QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
-  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery-preview"
-curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Token $QOVERY_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery-preview (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery-preview"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery-preview (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 > **API rule:** The `User-Agent` header above is required on **every** `curl` call to `api.qovery.com` — not just this tracking call. Never omit it.

--- a/qovery-signup/SKILL.md
+++ b/qovery-signup/SKILL.md
@@ -19,13 +19,23 @@ The whole flow leans on the **Qovery CLI's own credential store** — after `qov
 **EXECUTE THIS BASH COMMAND after the user is authenticated (Phase 2). Skip it before auth — there is no token yet.**
 
 ```bash
-QOVERY_ORG_ID=$(qovery api organization 2>/dev/null | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery-signup"
-[ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Bearer $(qovery auth token --print 2>/dev/null)" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery-signup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery-signup"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery-signup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 > **API rule:** every `curl` to `api.qovery.com` MUST carry the `User-Agent` header above. Prefer the `qovery` CLI / `qovery api` over raw curl whenever possible — it authenticates internally.

--- a/qovery-signup/SKILL.md
+++ b/qovery-signup/SKILL.md
@@ -19,22 +19,19 @@ The whole flow leans on the **Qovery CLI's own credential store** — after `qov
 **EXECUTE THIS BASH COMMAND after the user is authenticated (Phase 2). Skip it before auth — there is no token yet.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery-signup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery-signup"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery-signup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-signup"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-signup"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery-speedup/SKILL.md
+++ b/qovery-speedup/SKILL.md
@@ -19,14 +19,23 @@ For deployment failures use `qovery-troubleshoot`. For cost optimization use `qo
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
-QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
-  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery-speedup"
-curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Token $QOVERY_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery-speedup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery-speedup"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery-speedup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 > **API rule:** The `User-Agent` header above is required on **every** `curl` call to `api.qovery.com` — not just this tracking call. Never omit it.

--- a/qovery-speedup/SKILL.md
+++ b/qovery-speedup/SKILL.md
@@ -19,22 +19,19 @@ For deployment failures use `qovery-troubleshoot`. For cost optimization use `qo
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery-speedup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery-speedup"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery-speedup (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-speedup"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-speedup"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery-terraform/SKILL.md
+++ b/qovery-terraform/SKILL.md
@@ -19,14 +19,23 @@ Supports single environments or multiple environments merged into one configurat
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
-QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
-  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery-terraform"
-curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Token $QOVERY_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery-terraform (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery-terraform"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery-terraform (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 > **API rule:** The `User-Agent` header above is required on **every** `curl` call to `api.qovery.com` — not just this tracking call. Never omit it.

--- a/qovery-terraform/SKILL.md
+++ b/qovery-terraform/SKILL.md
@@ -19,22 +19,19 @@ Supports single environments or multiple environments merged into one configurat
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery-terraform (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery-terraform"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery-terraform (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-terraform"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-terraform"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery-troubleshoot/SKILL.md
+++ b/qovery-troubleshoot/SKILL.md
@@ -19,22 +19,19 @@ For slow-but-working deployments use `qovery-speedup`. For cost-driven optimizat
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery-troubleshoot (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery-troubleshoot"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery-troubleshoot (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-troubleshoot"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery-troubleshoot"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery-troubleshoot/SKILL.md
+++ b/qovery-troubleshoot/SKILL.md
@@ -19,14 +19,23 @@ For slow-but-working deployments use `qovery-speedup`. For cost-driven optimizat
 **EXECUTE THIS BASH COMMAND IMMEDIATELY — before any other action. Do not skip.**
 
 ```bash
-QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
-  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery-troubleshoot"
-curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Token $QOVERY_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery-troubleshoot (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery-troubleshoot"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery-troubleshoot (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 > **API rule:** The `User-Agent` header above is required on **every** `curl` call to `api.qovery.com` — not just this tracking call. Never omit it.

--- a/qovery/SKILL.md
+++ b/qovery/SKILL.md
@@ -34,22 +34,19 @@ Do NOT use this skill if the user's intent clearly matches a specialized skill â
 **EXECUTE THIS BASH COMMAND IMMEDIATELY â€” before any other action. Do not skip.**
 
 ```bash
+QOVERY_SKILLS_UA="QoverySkill/qovery (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)"
 if [ -n "${QOVERY_API_TOKEN:-}" ]; then
-  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
-elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
-  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
-else
-  QOVERY_AUTH_HEADER=""
-fi
-if [ -n "$QOVERY_AUTH_HEADER" ]; then
-  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
-    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-  SKILL_NAME="qovery"
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
   [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-    -H "Authorization: $QOVERY_AUTH_HEADER" \
-    -H "Content-Type: application/json" \
-    -H "User-Agent: QoverySkill/qovery (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+    -H "Authorization: Token $QOVERY_API_TOKEN" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery"}' > /dev/null 2>&1 || true
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: Bearer $(qovery auth token --print)" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id // empty' 2>/dev/null)
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: Bearer $(qovery auth token --print)" -H "Content-Type: application/json" -H "User-Agent: $QOVERY_SKILLS_UA" \
+    -d '{"skill_name":"qovery"}' > /dev/null 2>&1 || true
 fi
 ```
 

--- a/qovery/SKILL.md
+++ b/qovery/SKILL.md
@@ -34,14 +34,23 @@ Do NOT use this skill if the user's intent clearly matches a specialized skill â
 **EXECUTE THIS BASH COMMAND IMMEDIATELY â€” before any other action. Do not skip.**
 
 ```bash
-QOVERY_ORG_ID=$(curl -s -H "Authorization: Token $QOVERY_API_TOKEN" \
-  "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
-SKILL_NAME="qovery"
-curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
-  -H "Authorization: Token $QOVERY_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: QoverySkill/qovery (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
-  -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+if [ -n "${QOVERY_API_TOKEN:-}" ]; then
+  QOVERY_AUTH_HEADER="Token $QOVERY_API_TOKEN"
+elif command -v qovery >/dev/null 2>&1 && qovery auth token --print >/dev/null 2>&1; then
+  QOVERY_AUTH_HEADER="Bearer $(qovery auth token --print)"
+else
+  QOVERY_AUTH_HEADER=""
+fi
+if [ -n "$QOVERY_AUTH_HEADER" ]; then
+  QOVERY_ORG_ID=$(curl -s -H "Authorization: $QOVERY_AUTH_HEADER" \
+    "https://api.qovery.com/organization" | jq -r '.results[0].id' 2>/dev/null)
+  SKILL_NAME="qovery"
+  [ -n "$QOVERY_ORG_ID" ] && curl -s -X POST "https://api.qovery.com/organization/${QOVERY_ORG_ID}/skill-tracking" \
+    -H "Authorization: $QOVERY_AUTH_HEADER" \
+    -H "Content-Type: application/json" \
+    -H "User-Agent: QoverySkill/qovery (version:$(cat _version.txt 2>/dev/null || echo unknown); https://github.com/Qovery/qovery-skills)" \
+    -d "{\"skill_name\":\"${SKILL_NAME}\"}" > /dev/null 2>&1 || true
+fi
 ```
 
 ---


### PR DESCRIPTION
## Summary

Fixes skill usage tracking when the user is authenticated via the Qovery CLI instead of a `$QOVERY_API_TOKEN` environment variable. Previously, the tracking block in every SKILL.md only used `Authorization: Token $QOVERY_API_TOKEN` — if the env var was unset the tracking call silently failed, even when the CLI was fully authenticated.

Now each skill resolves the auth header with a fallback cascade:

1. `$QOVERY_API_TOKEN` env var (existing behavior, unchanged)
2. `qovery auth token --print` via the CLI credential store
3. No auth available — skip tracking silently

### Changed Files

- `qovery/SKILL.md`
- `qovery-deploy/SKILL.md`
- `qovery-onboard/SKILL.md`
- `qovery-optimize/SKILL.md`
- `qovery-policy-token/SKILL.md`
- `qovery-preview/SKILL.md`
- `qovery-signup/SKILL.md`
- `qovery-speedup/SKILL.md`
- `qovery-terraform/SKILL.md`
- `qovery-troubleshoot/SKILL.md`

All 10 skills now share the same auth resolution pattern for the tracking call. No functional change.