### PR TITLE
fix: correct AWS role-based credentials payload in onboard/deploy skills

### DIFF
--- a/qovery-deploy/reference/phase2b-cluster-setup.md
+++ b/qovery-deploy/reference/phase2b-cluster-setup.md
@@ -54,7 +54,7 @@ This is the most secure method. It uses temporary credentials that auto-rotate.
      }'
    ```
 
-   `AwsCredentialsRequest` is a discriminated union (`type`: `AWS_ROLE` or `AWS_STATIC`). Omitting `type`, or using the field name `assumed_role_arn` instead of `role_arn`, makes the API fall back to parsing the body as `AwsStaticCredentialsRequest` and fail with a misleading `access_key_id is required` error — that does NOT mean role/ARN credentials are unsupported.
+   IMPORTANT: The `type` field (`AWS_ROLE` or `AWS_STATIC`) is required, and the ARN field is `role_arn`, not `assumed_role_arn`. Getting either wrong makes the API parse the body as static credentials and fail with a misleading `access_key_id is required` error — that does not mean role/ARN credentials are unsupported.
 
 **AWS Credentials (Static Keys — Alternative)**
 

--- a/qovery-deploy/reference/phase2b-cluster-setup.md
+++ b/qovery-deploy/reference/phase2b-cluster-setup.md
@@ -48,10 +48,13 @@ This is the most secure method. It uses temporary credentials that auto-rotate.
      -H "Authorization: Token $QOVERY_API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{
+       "type": "AWS_ROLE",
        "name": "aws-production",
-       "assumed_role_arn": "arn:aws:iam::123456789012:role/qovery-role"
+       "role_arn": "arn:aws:iam::123456789012:role/qovery-role"
      }'
    ```
+
+   `AwsCredentialsRequest` is a discriminated union (`type`: `AWS_ROLE` or `AWS_STATIC`). Omitting `type`, or using the field name `assumed_role_arn` instead of `role_arn`, makes the API fall back to parsing the body as `AwsStaticCredentialsRequest` and fail with a misleading `access_key_id is required` error — that does NOT mean role/ARN credentials are unsupported.
 
 **AWS Credentials (Static Keys — Alternative)**
 
@@ -66,6 +69,7 @@ If the user cannot use STS Assume Role:
      -H "Authorization: Token $QOVERY_API_TOKEN" \
      -H "Content-Type: application/json" \
      -d '{
+       "type": "AWS_STATIC",
        "name": "aws-production",
        "access_key_id": "AKIA...",
        "secret_access_key": "..."

--- a/qovery-onboard/reference/phase3-execute-setup.md
+++ b/qovery-onboard/reference/phase3-execute-setup.md
@@ -45,8 +45,10 @@ Save credentials:
 curl -s -X POST "https://api.qovery.com/organization/{orgId}/aws/credentials" \
   -H "Authorization: Token $QOVERY_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"name": "aws-production", "assumed_role_arn": "arn:aws:iam::XXXXXXXXXXXX:role/qovery-role"}'
+  -d '{"type": "AWS_ROLE", "name": "aws-production", "role_arn": "arn:aws:iam::XXXXXXXXXXXX:role/qovery-role"}'
 ```
+
+`AwsCredentialsRequest` is a discriminated union — the `type` field (`AWS_ROLE` or `AWS_STATIC`) is required. Omitting it makes the API try to parse the body as `AwsStaticCredentialsRequest` and fail with a misleading `access_key_id is required` error, which looks like ARN isn't supported when it is.
 
 > "Cloud credentials saved. You can verify them in the Qovery Console at Organization Settings > Cloud Credentials."
 

--- a/qovery-onboard/reference/phase3-execute-setup.md
+++ b/qovery-onboard/reference/phase3-execute-setup.md
@@ -48,7 +48,7 @@ curl -s -X POST "https://api.qovery.com/organization/{orgId}/aws/credentials" \
   -d '{"type": "AWS_ROLE", "name": "aws-production", "role_arn": "arn:aws:iam::XXXXXXXXXXXX:role/qovery-role"}'
 ```
 
-`AwsCredentialsRequest` is a discriminated union — the `type` field (`AWS_ROLE` or `AWS_STATIC`) is required. Omitting it makes the API try to parse the body as `AwsStaticCredentialsRequest` and fail with a misleading `access_key_id is required` error, which looks like ARN isn't supported when it is.
+IMPORTANT: The `type` field (`AWS_ROLE` or `AWS_STATIC`) is required. Without it, the API parses the body as static credentials and fails with a misleading `access_key_id is required` error — that does not mean role/ARN credentials are unsupported.
 
 > "Cloud credentials saved. You can verify them in the Qovery Console at Organization Settings > Cloud Credentials."
 


### PR DESCRIPTION
## Summary
- `POST /organization/{orgId}/aws/credentials` expects `AwsCredentialsRequest`, a discriminated union (`type`: `AWS_ROLE` or `AWS_STATIC`).
- Both skills documented a payload missing the `type` field and using a non-existent field name (`assumed_role_arn` instead of `role_arn`).
- Without `type`, the API falls back to parsing the body as `AwsStaticCredentialsRequest` and returns a misleading `access_key_id is required` error — making it look like STS role/ARN credentials aren't supported, when they are.

## Changes
- `qovery-onboard/reference/phase3-execute-setup.md`: fixed the AWS role credentials curl example.
- `qovery-deploy/reference/phase2b-cluster-setup.md`: fixed both the role and static credentials curl examples, added the `type` field to each, and a note explaining the discriminator.

## Test plan
- [ ] Run through `qovery-onboard` with AWS STS role credentials and confirm the documented `curl` call succeeds without falling back to static keys.